### PR TITLE
Web API should now Rely on Pem files Directly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,13 +54,6 @@ Now run these commands
 
 ```shell
 mkcert -key-file key.pem -cert-file cert.pem localhost
-mkcert -pkcs12 localhost
-```
-
-Then you need to rename the localhost file
-
-```shell
-mv .\localhost.p12 localhost.pfx
 ```
 
 When you visit the sites, both Chrome and firefox will consider the certificates to be invalid, as it doesn't trust
@@ -292,12 +285,10 @@ mkdir ~/.aspnet/https -p
 cd ~/.aspnet/https
 
 mkcert -cert-file cert.pem -key-file key.pem localhost
-mkcert -p12-file localhost.pfx -pkcs12 localhost
-
 ```
 
-In your env file, add this
-If you use Linux
+Since you use linux, you need to add this to your env file.  UserProfile isn't predefined on linux machines like it is
+on windows
 ```ini
 # If you use linux, set this to your home directory
 USERPROFILE="/home/<username>"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,8 +31,8 @@ services:
       - ASPNETCORE_HTTPS_PORTS=5001
       - ASPNETCORE_HTTP_PORTS=5000
       - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_Kestrel__Certificates__Default__Password=${CERTIFICATE_PASSWORD}
-      - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/localhost.pfx
+      - ASPNETCORE_Kestrel__Certificates__Default__KeyPath=/https/key.pem
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/cert.pem
       - ConnectionStrings__DefaultConnection=Host=expressed-realms-db;Port=5432;Database=${DB_NAME};Username=${DB_USER};Password=${DB_PASSWORD}
       - SENDGRID_HOST=http://expressed-realms-sendgrid-mock:3000
       - SENDGRID_API_KEY=${SENDGRID_API_KEY}


### PR DESCRIPTION
- Web Api should now rely on the pem files directly.  
- Removed instructions on how to create the pfx files on both windows and fedora.