### PR TITLE
Add faction dropdown UI side

### DIFF
--- a/expressedrealms.client/cypress/Components/charcters/character/AddCharacter.cy.ts
+++ b/expressedrealms.client/cypress/Components/charcters/character/AddCharacter.cy.ts
@@ -6,7 +6,6 @@ const expression = 'expression';
 const expressionHelp = 'expression-help';
 const faction = 'faction';
 const factionHelp = 'faction-help';
-const factionDescription = 'faction-description';
 const background = 'background';
 const backgroundHelp = 'background-help'
 
@@ -19,6 +18,11 @@ const expressionValues = [
 const factionValues = [
     { id: 4, name: "Too", description: "Far" },
     { id: 5, name: "Loo", description: "Yoo" }
+]
+
+const factionValues2 = [
+    { id: 6, name: "Hoo", description: "Gar" },
+    { id: 7, name: "Moo", description: "Boo" }
 ]
 
 describe('<AddCharacter />', () => {
@@ -35,10 +39,15 @@ describe('<AddCharacter />', () => {
             }
         }).as('addOptions');
 
-        cy.intercept('GET', '/api/characters/factionOptions/*', {
+        cy.intercept('GET', '/api/characters/factionOptions/1', {
             statusCode: 200,
             body: factionValues
         }).as('factionOptions');
+
+        cy.intercept('GET', '/api/characters/factionOptions/2', {
+            statusCode: 200,
+            body: factionValues2
+        }).as('factionOptions2');
         
         cy.mount(addUserProfile);
     });
@@ -46,8 +55,7 @@ describe('<AddCharacter />', () => {
     it('Loading the page doesn\'t validate right away', () => {
         cy.dataCy(nameHelp).should('not.be.visible');
         cy.dataCy(backgroundHelp).should('not.be.visible');
-        cy.dataCy(factionHelp).should('not.be.visible');
-        cy.dataCy(factionDescription).should('be.empty');
+        cy.dataCy(factionHelp).should('not.exist');
     });
     
     it('Name Field follows all Schema Validations', () => {
@@ -74,12 +82,12 @@ describe('<AddCharacter />', () => {
 
     it('Faction Field Populates Data', () => {
         // Faction needs to be disabled until after an expression has been selected
-        cy.dataCy(faction).should('have.class', 'p-disabled');
+        cy.dataCy(faction).should('not.exist');
         cy.dataCy(expression).click();
         cy.get("#expression_0").click();
         cy.get("@factionOptions");
         // Select after selecting, it should now be visable and testable
-        cy.dataCy(faction).should('not.have.class', 'p-disabled');
+        cy.dataCy(faction).should('exist');
         cy.dataCy(addCharacterButton).click();
         cy.dataCy(factionHelp).contains("Faction is a required field");
         cy.dataCy(faction).click();
@@ -88,11 +96,11 @@ describe('<AddCharacter />', () => {
         });
         cy.get("#faction_0").click();
         cy.dataCy(factionHelp).should('not.be.visible');
-        cy.dataCy("faction-description").contains(factionValues[0].description);
         // If you change expression, it should clear out the old stuff
         cy.dataCy(expression).click();
         cy.get("#expression_1").click();
-        cy.dataCy(factionDescription).should('be.empty');
+        cy.get("@factionOptions2")
+        cy.dataCy(factionHelp).contains("Faction is a required field");
     })
 
     it('Passes Data Through Data To API', () => {

--- a/expressedrealms.client/cypress/Components/charcters/character/AddCharacter.cy.ts
+++ b/expressedrealms.client/cypress/Components/charcters/character/AddCharacter.cy.ts
@@ -6,6 +6,7 @@ const expression = 'expression';
 const expressionHelp = 'expression-help';
 const faction = 'faction';
 const factionHelp = 'faction-help';
+const factionDescription = 'faction-description';
 const background = 'background';
 const backgroundHelp = 'background-help'
 
@@ -34,7 +35,7 @@ describe('<AddCharacter />', () => {
             }
         }).as('addOptions');
 
-        cy.intercept('GET', '/api/characters/factionOptions/1', {
+        cy.intercept('GET', '/api/characters/factionOptions/*', {
             statusCode: 200,
             body: factionValues
         }).as('factionOptions');
@@ -46,6 +47,7 @@ describe('<AddCharacter />', () => {
         cy.dataCy(nameHelp).should('not.be.visible');
         cy.dataCy(backgroundHelp).should('not.be.visible');
         cy.dataCy(factionHelp).should('not.be.visible');
+        cy.dataCy(factionDescription).should('be.empty');
     });
     
     it('Name Field follows all Schema Validations', () => {
@@ -71,10 +73,12 @@ describe('<AddCharacter />', () => {
     })
 
     it('Faction Field Populates Data', () => {
+        // Faction needs to be disabled until after an expression has been selected
         cy.dataCy(faction).should('have.class', 'p-disabled');
         cy.dataCy(expression).click();
         cy.get("#expression_0").click();
         cy.get("@factionOptions");
+        // Select after selecting, it should now be visable and testable
         cy.dataCy(faction).should('not.have.class', 'p-disabled');
         cy.dataCy(addCharacterButton).click();
         cy.dataCy(factionHelp).contains("Faction is a required field");
@@ -85,6 +89,10 @@ describe('<AddCharacter />', () => {
         cy.get("#faction_0").click();
         cy.dataCy(factionHelp).should('not.be.visible');
         cy.dataCy("faction-description").contains(factionValues[0].description);
+        // If you change expression, it should clear out the old stuff
+        cy.dataCy(expression).click();
+        cy.get("#expression_1").click();
+        cy.dataCy(factionDescription).should('be.empty');
     })
 
     it('Passes Data Through Data To API', () => {

--- a/expressedrealms.client/cypress/Components/charcters/character/AddCharacter.cy.ts
+++ b/expressedrealms.client/cypress/Components/charcters/character/AddCharacter.cy.ts
@@ -4,6 +4,8 @@ const name = 'name';
 const nameHelp = 'name-help';
 const expression = 'expression';
 const expressionHelp = 'expression-help';
+const faction = 'faction';
+const factionHelp = 'faction-help';
 const background = 'background';
 const backgroundHelp = 'background-help'
 
@@ -11,6 +13,11 @@ const addCharacterButton = 'add-character-button';
 const expressionValues = [
     { id: 1, name: "Foo", shortDescription: "Bar" },
     { id: 2, name: "Boo", shortDescription: "Goo" }
+]
+
+const factionValues = [
+    { id: 4, name: "Too", description: "Far" },
+    { id: 5, name: "Loo", description: "Yoo" }
 ]
 
 describe('<AddCharacter />', () => {
@@ -26,6 +33,11 @@ describe('<AddCharacter />', () => {
                 expressions: expressionValues
             }
         }).as('addOptions');
+
+        cy.intercept('GET', '/api/characters/factionOptions/1', {
+            statusCode: 200,
+            body: factionValues
+        }).as('factionOptions');
         
         cy.mount(addUserProfile);
     });
@@ -33,6 +45,7 @@ describe('<AddCharacter />', () => {
     it('Loading the page doesn\'t validate right away', () => {
         cy.dataCy(nameHelp).should('not.be.visible');
         cy.dataCy(backgroundHelp).should('not.be.visible');
+        cy.dataCy(factionHelp).should('not.be.visible');
     });
     
     it('Name Field follows all Schema Validations', () => {
@@ -57,12 +70,31 @@ describe('<AddCharacter />', () => {
         cy.dataCy("expression-short-description").contains(expressionValues[0].shortDescription);
     })
 
+    it('Faction Field Populates Data', () => {
+        cy.dataCy(faction).should('have.class', 'p-disabled');
+        cy.dataCy(expression).click();
+        cy.get("#expression_0").click();
+        cy.get("@factionOptions");
+        cy.dataCy(faction).should('not.have.class', 'p-disabled');
+        cy.dataCy(addCharacterButton).click();
+        cy.dataCy(factionHelp).contains("Faction is a required field");
+        cy.dataCy(faction).click();
+        cy.get("#faction_list li").each(($ele, i) => {
+            expect($ele).to.have.text(factionValues[i].name)
+        });
+        cy.get("#faction_0").click();
+        cy.dataCy(factionHelp).should('not.be.visible');
+        cy.dataCy("faction-description").contains(factionValues[0].description);
+    })
+
     it('Passes Data Through Data To API', () => {
         
         cy.dataCy(name).clear();
         cy.dataCy(name).type("John Doe");
         cy.dataCy(expression).click();
         cy.get("#expression_0").click();
+        cy.dataCy(faction).click();
+        cy.get("#faction_0").click();
         cy.dataCy(background).clear();
         cy.dataCy(background).type("5555555555");
         cy.dataCy(addCharacterButton).click();
@@ -71,6 +103,7 @@ describe('<AddCharacter />', () => {
             name: 'John Doe',
             expressionId: expressionValues[0].id,
             background: '5555555555',
+            factionId: factionValues[0].id
         });
     });
     

--- a/expressedrealms.client/cypress/Components/charcters/character/EditCharacter.cy.ts
+++ b/expressedrealms.client/cypress/Components/charcters/character/EditCharacter.cy.ts
@@ -9,8 +9,14 @@ const backgroundHelp = 'background-help'
 const backgroundDefaultValue = "The anonymous person";
 const expression = "expression";
 const expressionHelp = 'expression-help'
+const faction = "faction";
+const factionHelp = "faction-help"
+const factionDefaultValue = 4;
 const expressionDefaultValue = "Adept";
-
+const factionValues = [
+    { id: 4, name: "Too", description: "Far" },
+    { id: 5, name: "Loo", description: "Yoo" }
+]
 describe('<EditCharacter />', () => {
     beforeEach(() => {
 
@@ -19,7 +25,8 @@ describe('<EditCharacter />', () => {
             body: {
                 name: nameDefaultValue,
                 background: backgroundDefaultValue,
-                expression: expressionDefaultValue
+                expression: expressionDefaultValue,
+                factionId: factionDefaultValue
             }
         }).as('getCharacter');
         
@@ -27,6 +34,11 @@ describe('<EditCharacter />', () => {
             statusCode: 200,
             body: [{}, {}, {}, {}, {}, {}]
         })
+        
+        cy.intercept('GET', '/api/characters/3/factionOptions', {
+            statusCode: 200,
+            body: factionValues
+        }).as('getFactionOptions');
 
         cy.intercept('PUT', '/api/characters', {
             statusCode: 200,
@@ -43,12 +55,15 @@ describe('<EditCharacter />', () => {
         cy.dataCy(nameHelp).should('not.be.visible');
         cy.dataCy(backgroundHelp).should('not.be.visible');
         cy.dataCy(expressionHelp).should('not.be.visible');
+        cy.dataCy(factionHelp).should('not.be.visible');
     });
     
     it('Loading Page Will Grab Data From API and Load It In', () => {
+        cy.get('@getFactionOptions');
         cy.dataCy(name).should("have.value", nameDefaultValue);
         cy.dataCy(background).should("have.value", backgroundDefaultValue);
         cy.dataCy(expression).should("have.value", expressionDefaultValue);
+        cy.dataCy(faction).contains(factionValues.find(x => x.id == factionDefaultValue).name);
     });
     
     it('Name Field follows all Schema Validations and Updates Automatically', () => {
@@ -72,6 +87,23 @@ describe('<EditCharacter />', () => {
     
     it('Expression Field is Disabled', () => {
         cy.dataCy(expression).should('be.disabled');
+    })
+
+    it('Faction Field Populates Data', () => {
+        cy.get("@getFactionOptions");
+        cy.dataCy(faction).click();
+        cy.get("#faction_list li").each(($ele, i) => {
+            expect($ele).to.have.text(factionValues[i].name)
+        });
+        cy.get("#faction_0").click();
+        cy.dataCy(factionHelp).should('not.be.visible');
+        cy.dataCy("faction-description").contains(factionValues[0].description);
+
+        cy.get('@updateCharacter').its('request.body')
+            .should('have.property', 'factionId', 4);
+        cy.get('@updateCharacter').its('request.body')
+            .should('have.property', 'id', '3');
+        cy.get('@toasterSuccess').should('have.been.calledWith', 'Successfully Updated Character Info!');
     })
 
     it('Background Follows all Schema Validations and Updates Automatically', () => {

--- a/expressedrealms.client/cypress/Components/charcters/character/EditCharacter.cy.ts
+++ b/expressedrealms.client/cypress/Components/charcters/character/EditCharacter.cy.ts
@@ -97,7 +97,6 @@ describe('<EditCharacter />', () => {
         });
         cy.get("#faction_0").click();
         cy.dataCy(factionHelp).should('not.be.visible');
-        cy.dataCy("faction-description").contains(factionValues[0].description);
 
         cy.get('@updateCharacter').its('request.body')
             .should('have.property', 'factionId', 4);

--- a/expressedrealms.client/cypress/README.md
+++ b/expressedrealms.client/cypress/README.md
@@ -49,3 +49,11 @@ Then for the actual testing (Tweak as needed)
 cy.get('@toasterSuccess').should('have.been.calledWith', 'Title', 'Message');
 cy.get('@toasterSuccess').should('have.been.calledWith', 'Message');
 ```
+
+## Testing Drop-Downs
+
+You need to use Contains to find the value.  You cannot verify the actual id, just the name of the option. Like so:
+
+```typescript
+cy.dataCy(faction).contains(factionValues.find(x => x.id == factionDefaultValue).name);
+```

--- a/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
+++ b/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
@@ -71,10 +71,10 @@ function redirectUser(openInNewTab:boolean) {
     <Skeleton v-if="showSkeleton" :id="dataCyTagCalc + '-skeleton'" class="w-100" height="3em" />
     <InputGroup v-else>
       <Dropdown
-          :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel" :data-cy="dataCyTagCalc"
-          class="w-100" :class="{ 'p-invalid': errorText }" v-bind="$attrs"
+        :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel" :data-cy="dataCyTagCalc"
+        class="w-100" :class="{ 'p-invalid': errorText }" v-bind="$attrs"
       />
-      <Button icon="pi pi-info-circle" severity="info" @click="redirectUser(props.redirectToDifferentPage)" @click.middle="redirectUser(true)" :disabled="!model"></Button>
+      <Button icon="pi pi-info-circle" severity="info" :disabled="!model" @click="redirectUser(props.redirectToDifferentPage)" @click.middle="redirectUser(true)" />
     </InputGroup>
     <small :data-cy="dataCyTagCalc + '-help'" class="text-danger">{{ errorText }}</small>
     <slot />

--- a/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
+++ b/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
@@ -7,7 +7,7 @@ import InputGroup from 'primevue/inputgroup';
 import Button from 'primevue/button'
 import Router from "@/router";
 
-const model = defineModel({ required: true, default: {}, type: Object });
+const model = defineModel({ required: false, default: {}, type: Object });
 
 defineOptions({
   inheritAttrs: false
@@ -74,7 +74,7 @@ function redirectUser(openInNewTab:boolean) {
           :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel" :data-cy="dataCyTagCalc"
           class="w-100" :class="{ 'p-invalid': errorText }" v-bind="$attrs"
       />
-      <Button icon="pi pi-info-circle" severity="info" @click="redirectUser(props.redirectToDifferentPage)" @click.middle="redirectUser(true)"></Button>
+      <Button icon="pi pi-info-circle" severity="info" @click="redirectUser(props.redirectToDifferentPage)" @click.middle="redirectUser(true)" :disabled="!model"></Button>
     </InputGroup>
     <small :data-cy="dataCyTagCalc + '-help'" class="text-danger">{{ errorText }}</small>
     <slot />

--- a/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
+++ b/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+
+import Dropdown from 'primevue/dropdown';
+import {computed} from "vue";
+import Skeleton from 'primevue/skeleton';
+import InputGroup from 'primevue/inputgroup';
+import Button from 'primevue/button'
+import Router from "@/router";
+
+const model = defineModel({ required: true, default: {}, type: Object });
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const props = defineProps({
+  fieldName: {
+    type: String,
+    required: true,
+  },
+  options: {
+    type: Array,
+    required: true
+  },
+  optionLabel: {
+    type: String,
+    required: true
+  },
+  dataCyTag: {
+    type: String,
+    default: ""
+  },
+  errorText: {
+    type: String,
+    default: ""
+  },
+  showSkeleton: {
+    type: Boolean,
+    default: false
+  },
+  redirectUrl:{
+    type: String,
+    required: true
+  }
+});
+
+const dataCyTagCalc = computed(() => {
+  if(props.dataCyTag != ""){
+    return props.dataCyTag;
+  }
+  return props.fieldName.replace(" ", "-").toLowerCase();
+});
+
+function redirectUser() {
+  Router.push(props.redirectUrl);
+}
+
+</script>
+
+<template>
+  <div class="mb-3">
+    <label :for="dataCyTagCalc">{{ props.fieldName }}</label>
+    <Skeleton v-if="showSkeleton" :id="dataCyTagCalc + '-skeleton'" class="w-100" height="3em" />
+    <InputGroup v-else>
+      <Dropdown
+          :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel" :data-cy="dataCyTagCalc"
+          class="w-100" :class="{ 'p-invalid': errorText }" v-bind="$attrs"
+      />
+      <Button icon="pi pi-info-circle" severity="info" @click="redirectUser"></Button>
+    </InputGroup>
+    <small :data-cy="dataCyTagCalc + '-help'" class="text-danger">{{ errorText }}</small>
+    <slot />
+  </div>
+</template>

--- a/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
+++ b/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
@@ -55,8 +55,8 @@ const dataCyTagCalc = computed(() => {
   return props.fieldName.replace(" ", "-").toLowerCase();
 });
 
-function redirectUser() {
-  if(!props.redirectToDifferentPage){
+function redirectUser(openInNewTab:boolean) {
+  if(!openInNewTab){
     Router.push(props.redirectUrl);
   }else{
     window.open(props.redirectUrl, "_blank");
@@ -74,7 +74,7 @@ function redirectUser() {
           :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel" :data-cy="dataCyTagCalc"
           class="w-100" :class="{ 'p-invalid': errorText }" v-bind="$attrs"
       />
-      <Button icon="pi pi-info-circle" severity="info" @click="redirectUser"></Button>
+      <Button icon="pi pi-info-circle" severity="info" @click="redirectUser(props.redirectToDifferentPage)" @click.middle="redirectUser(true)"></Button>
     </InputGroup>
     <small :data-cy="dataCyTagCalc + '-help'" class="text-danger">{{ errorText }}</small>
     <slot />

--- a/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
+++ b/expressedrealms.client/src/FormWrappers/DropdownInfoWrapper.vue
@@ -41,6 +41,10 @@ const props = defineProps({
   redirectUrl:{
     type: String,
     required: true
+  },
+  redirectToDifferentPage:{
+    type: Boolean,
+    default: false
   }
 });
 
@@ -52,7 +56,11 @@ const dataCyTagCalc = computed(() => {
 });
 
 function redirectUser() {
-  Router.push(props.redirectUrl);
+  if(!props.redirectToDifferentPage){
+    Router.push(props.redirectUrl);
+  }else{
+    window.open(props.redirectUrl, "_blank");
+  }
 }
 
 </script>

--- a/expressedrealms.client/src/FormWrappers/DropdownWrapper.vue
+++ b/expressedrealms.client/src/FormWrappers/DropdownWrapper.vue
@@ -4,7 +4,7 @@ import Dropdown from 'primevue/dropdown';
 import {computed} from "vue";
 import Skeleton from 'primevue/skeleton';
 
-const model = defineModel({ required: true, default: {}, type: Number });
+const model = defineModel({ required: true, default: {}, type: Object });
 
 defineOptions({
   inheritAttrs: false

--- a/expressedrealms.client/src/FormWrappers/DropdownWrapper.vue
+++ b/expressedrealms.client/src/FormWrappers/DropdownWrapper.vue
@@ -51,7 +51,7 @@ const dataCyTagCalc = computed(() => {
     <label :for="dataCyTagCalc">{{ props.fieldName }}</label>
     <Skeleton v-if="showSkeleton" :id="dataCyTagCalc + '-skeleton'" class="w-100" height="3em" />
     <Dropdown
-      :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel" :data-cy="dataCyTagCalc"
+      v-else :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel" :data-cy="dataCyTagCalc"
       class="w-100" :class="{ 'p-invalid': errorText }" v-bind="$attrs"
     />
     <small :data-cy="dataCyTagCalc + '-help'" class="text-danger">{{ errorText }}</small>

--- a/expressedrealms.client/src/FormWrappers/DropdownWrapper.vue
+++ b/expressedrealms.client/src/FormWrappers/DropdownWrapper.vue
@@ -51,7 +51,8 @@ const dataCyTagCalc = computed(() => {
     <label :for="dataCyTagCalc">{{ props.fieldName }}</label>
     <Skeleton v-if="showSkeleton" :id="dataCyTagCalc + '-skeleton'" class="w-100" height="3em" />
     <Dropdown
-      v-else :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel" :data-cy="dataCyTagCalc"
+      v-else :id="dataCyTagCalc" v-model="model" :options="options" :option-label="optionLabel"
+      :data-cy="dataCyTagCalc"
       class="w-100" :class="{ 'p-invalid': errorText }" v-bind="$attrs"
     />
     <small :data-cy="dataCyTagCalc + '-help'" class="text-danger">{{ errorText }}</small>

--- a/expressedrealms.client/src/components/characters/character/AddCharacter.vue
+++ b/expressedrealms.client/src/components/characters/character/AddCharacter.vue
@@ -68,7 +68,7 @@ function loadFactions(){
 
 
 const expressionRedirectURL = computed(() => {
-  if(!isLoadingFactions.value && faction){
+  if(!isLoadingFactions.value && faction.value){
     return `/expressions/${expression.value.name.toLowerCase()}#${makeIdSafe(faction.value.name)}`;
   }
   return '';

--- a/expressedrealms.client/src/components/characters/character/AddCharacter.vue
+++ b/expressedrealms.client/src/components/characters/character/AddCharacter.vue
@@ -66,14 +66,12 @@ function loadFactions(){
       })
 }
 
-
 const expressionRedirectURL = computed(() => {
   if(!isLoadingFactions.value && faction.value){
     return `/expressions/${expression.value.name.toLowerCase()}#${makeIdSafe(faction.value.name)}`;
   }
   return '';
 })
-
 
 </script>
 
@@ -86,12 +84,18 @@ const expressionRedirectURL = computed(() => {
       <template #content>
         <form @submit="onSubmit">
           <InputTextWrapper v-model="name" field-name="Name" :error-text="errors.name" />
-          <DropdownWrapper v-model="expression" option-label="name" :options="expressions" field-name="Expression" :error-text="errors.expressionId" @change="loadFactions()" :show-skeleton="isLoadingExpressions">
+          <DropdownWrapper
+            v-model="expression" option-label="name" :options="expressions" field-name="Expression" :error-text="errors.expressionId"
+            :show-skeleton="isLoadingExpressions" @change="loadFactions()"
+          >
             <div data-cy="expression-short-description" class="m-2">
               {{ expression?.shortDescription ?? "" }}
             </div>
           </DropdownWrapper>
-          <DropdownInfoWrapper v-if="expression" v-model="faction" option-label="name" :options="factions" field-name="Faction" :error-text="errors.factionId" :disabled="!expression" :redirect-url="expressionRedirectURL" :show-skeleton="isLoadingFactions" :redirect-to-different-page="true"/>
+          <DropdownInfoWrapper
+            v-if="expression" v-model="faction" option-label="name" :options="factions" field-name="Faction"
+            :error-text="errors.factionId" :disabled="!expression" :redirect-url="expressionRedirectURL" :show-skeleton="isLoadingFactions" :redirect-to-different-page="true"
+          />
           <TextAreaWrapper v-model="background" field-name="Background" :error-text="errors.background" />
           <Button data-cy="add-character-button" label="Add Character" class="w-100 mb-2" type="submit" />
         </form>

--- a/expressedrealms.client/src/components/characters/character/AddCharacter.vue
+++ b/expressedrealms.client/src/components/characters/character/AddCharacter.vue
@@ -54,6 +54,7 @@ const onSubmit = handleSubmit((values) => {
 function loadFactions(){
   axios.get(`/api/characters/factionOptions/${expression.value.id}`)
       .then((response) => {
+        faction.value = null;
         factions.value = response.data;
       })
 }

--- a/expressedrealms.client/src/components/characters/character/AddCharacter.vue
+++ b/expressedrealms.client/src/components/characters/character/AddCharacter.vue
@@ -19,14 +19,18 @@ const { defineField, handleSubmit, errors } = useForm({
     background: string()
         .label('Background'),
     expressionId: object().required()
-        .label("Expression")
+        .label("Expression"),
+    factionId: object().required()
+        .label("Faction")
   })
 });
 
 const [name] = defineField('name');
 const [background] = defineField('background');
 const [expression] = defineField('expressionId');
+const [faction] = defineField('factionId');
 const expressions = ref([]);
+const factions = ref([]);
 
 onMounted(() =>{
   axios.get(`/api/characters/options`)
@@ -39,12 +43,20 @@ const onSubmit = handleSubmit((values) => {
   axios.post('/api/characters', {
     name: values.name,
     expressionId: values.expressionId.id,
-    background: values.background
+    background: values.background,
+    factionId: values.factionId.id
   })
       .then(() => {
         Router.push("/characters");
       });
 });
+
+function loadFactions(){
+  axios.get(`/api/characters/factionOptions/${expression.value.id}`)
+      .then((response) => {
+        factions.value = response.data;
+      })
+}
 
 </script>
 
@@ -57,10 +69,13 @@ const onSubmit = handleSubmit((values) => {
       <template #content>
         <form @submit="onSubmit">
           <InputTextWrapper v-model="name" field-name="Name" :error-text="errors.name" />
-          <DropdownWrapper v-model="expression" option-label="name" :options="expressions" field-name="Expression" :error-text="errors.expressionId">
+          <DropdownWrapper v-model="expression" option-label="name" :options="expressions" field-name="Expression" :error-text="errors.expressionId" @change="loadFactions()">
             <div data-cy="expression-short-description" class="m-2">
               {{ expression?.shortDescription ?? "" }}
             </div>
+          </DropdownWrapper>
+          <DropdownWrapper v-model="faction" option-label="name" :options="factions" field-name="Faction" :error-text="errors.factionId" :disabled="!expression">
+            <div data-cy="faction-description" class="m-2" v-html="faction?.description ?? ''" ></div>
           </DropdownWrapper>
           <TextAreaWrapper v-model="background" field-name="Background" :error-text="errors.background" />
           <Button data-cy="add-character-button" label="Add Character" class="w-100 mb-2" type="submit" />

--- a/expressedrealms.client/src/components/characters/character/EditCharacter.vue
+++ b/expressedrealms.client/src/components/characters/character/EditCharacter.vue
@@ -16,11 +16,11 @@ import SkeletonWrapper from "@/FormWrappers/SkeletonWrapper.vue";
 import DropdownInfoWrapper from "@/FormWrappers/DropdownInfoWrapper.vue";
 import {makeIdSafe} from "@/utilities/stringUtilities";
 
-interface faction{
+interface Faction{
   id: number,
   name: string,
   description: string
-};
+}
 
 onMounted(() =>{
   axios.get(`/api/characters/${route.params.id}`)
@@ -38,7 +38,6 @@ onMounted(() =>{
             })
       });
   
-  
 });
 
 const { defineField, handleSubmit, errors } = useForm({
@@ -46,7 +45,7 @@ const { defineField, handleSubmit, errors } = useForm({
     name: string().required()
         .max(150)
         .label("Name"),
-    faction: object<faction>().required()
+    faction: object<Faction>().required()
         .label('Faction'),
     background: string()
         .label('Background'),
@@ -110,7 +109,10 @@ let expressionRedirectURL = computed(() => {
         <form @submit="onSubmit">
           <InputTextWrapper v-model="name" field-name="Name" :error-text="errors.name" :show-skeleton="isLoading" @change="onSubmit" />
           <InputTextWrapper v-model="expression" field-name="Expression" disabled :show-skeleton="isLoading" @change="onSubmit" />
-          <DropdownInfoWrapper v-model="faction" option-label="name" :options="factions" field-name="Faction" :error-text="errors.factionId" :show-skeleton="isLoading" :redirect-url="expressionRedirectURL" @change="onSubmit" />
+          <DropdownInfoWrapper
+            v-model="faction" option-label="name" :options="factions" field-name="Faction" :error-text="errors.factionId"
+            :show-skeleton="isLoading" :redirect-url="expressionRedirectURL" @change="onSubmit"
+          />
           <TextAreaWrapper v-model="background" field-name="Background" :error-text="errors.background" :show-skeleton="isLoading" @change="onSubmit" />
         </form>
       </template>

--- a/expressedrealms.client/src/components/characters/character/EditCharacter.vue
+++ b/expressedrealms.client/src/components/characters/character/EditCharacter.vue
@@ -6,14 +6,15 @@ import { object, string }  from 'yup';
 import Card from "primevue/card";
 import InputTextWrapper from "@/FormWrappers/InputTextWrapper.vue";
 import TextAreaWrapper from "@/FormWrappers/TextAreaWrapper.vue";
-import {onMounted, ref} from "vue";
+import {onMounted, ref, computed} from "vue";
 import { useRoute } from 'vue-router'
 import toaster from "@/services/Toasters";
 import SmallStatDisplay from "@/components/characters/character/SmallStatDisplay.vue";
 const route = useRoute()
 import Breadcrumb from 'primevue/breadcrumb';
 import SkeletonWrapper from "@/FormWrappers/SkeletonWrapper.vue";
-import DropdownWrapper from "@/FormWrappers/DropdownWrapper.vue";
+import DropdownInfoWrapper from "@/FormWrappers/DropdownInfoWrapper.vue";
+import {makeIdSafe} from "@/utilities/stringUtilities";
 
 interface faction{
   id: number,
@@ -27,7 +28,6 @@ onMounted(() =>{
         name.value = response.data.name;
         background.value = response.data.background;
         expression.value = response.data.expression;
-        //faction.value = response.data.factionId
         
         axios.get(`/api/characters/${route.params.id}/factionOptions`)
             .then((factionResponse) => {
@@ -46,7 +46,7 @@ const { defineField, handleSubmit, errors } = useForm({
     name: string().required()
         .max(150)
         .label("Name"),
-    faction: object().required()
+    faction: object<faction>().required()
         .label('Faction'),
     background: string()
         .label('Background'),
@@ -78,6 +78,14 @@ const home = ref({
   icon: 'pi pi-home',
   route: '/characters'
 });
+
+let expressionRedirectURL = computed(() => {
+  if(!isLoading.value){
+    return `/expressions/${expression.value.toLowerCase()}#${makeIdSafe(faction.value.name)}`;
+  }
+  return '';
+})
+
 </script>
 
 <template>
@@ -102,10 +110,8 @@ const home = ref({
         <form @submit="onSubmit">
           <InputTextWrapper v-model="name" field-name="Name" :error-text="errors.name" :show-skeleton="isLoading" @change="onSubmit" />
           <InputTextWrapper v-model="expression" field-name="Expression" disabled :show-skeleton="isLoading" @change="onSubmit" />
+          <DropdownInfoWrapper v-model="faction" option-label="name" :options="factions" field-name="Faction" :error-text="errors.factionId" :show-skeleton="isLoading" :redirect-url="expressionRedirectURL" @change="onSubmit" />
           <TextAreaWrapper v-model="background" field-name="Background" :error-text="errors.background" :show-skeleton="isLoading" @change="onSubmit" />
-          <DropdownWrapper v-model="faction" option-label="name" :options="factions" field-name="Faction" :error-text="errors.factionId" :show-skeleton="isLoading" @change="onSubmit" >
-            <div data-cy="faction-description" class="m-2" v-html="faction?.description ?? ''" ></div>
-          </DropdownWrapper>
         </form>
       </template>
     </Card>

--- a/expressedrealms.client/src/components/expressions/ExpressionBase.vue
+++ b/expressedrealms.client/src/components/expressions/ExpressionBase.vue
@@ -5,7 +5,7 @@ import axios from "axios";
 import {onBeforeRouteUpdate, useRoute} from 'vue-router'
 const route = useRoute()
 
-import {onMounted, ref } from "vue";
+import {onMounted, ref, nextTick } from "vue";
 import Card from "primevue/card";
 import ExpressionToC from "@/components/expressions/ExpressionToC.vue";
 import Skeleton from 'primevue/skeleton';
@@ -35,9 +35,13 @@ let sections = ref([
 const isLoading = ref(true);
 function fetchData(name: string) {
   axios.get(`/api/expression/${name}`)
-      .then((json) => {
+      .then(async (json) => {
         sections.value = json.data;
         isLoading.value = false;
+        if(location.hash){
+          await nextTick();
+          window.location.replace(location.hash);
+        }        
       });
 }
 


### PR DESCRIPTION
- Created a new DropdownInfoWrapper specifically for info lookups
  - This will show a blue icon button next to the drop-down that will redirect you to the page that the information is on.
  - Said button will only be clickable if a value is selected
  - One can control if the button will open a new tab or not
  - The button will support middle-click functionality
  - Default functionality will be to open on the same page unless the info button is middle clicked, in which case it will open in a new tab

- Add and Edit Character uses the new dropdown for factions now, including cypress tests
- Add Character now handles skeleton loading as well.

- Expression Page will now scroll you to the appropriate section if the path fragment exists after loading in data

- Fixed warnings on drop down menu
- Fixed bug where it was displaying the dropdown and loading bar at same time
