### PR TITLE
Fix expression in sections showing up

### DIFF
--- a/.github/workflows/DeployAPI.yml
+++ b/.github/workflows/DeployAPI.yml
@@ -24,6 +24,7 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
+      security-events: write
 
     steps:
       # Git Checkout

--- a/.github/workflows/DeployFrontEnd.yml
+++ b/.github/workflows/DeployFrontEnd.yml
@@ -23,6 +23,8 @@ jobs:
       issues: write
       pull-requests: write
       statuses: write
+      security-events: write
+
     steps:
       # Git Checkout
       - name: Checkout Code

--- a/api/ExpressedRealms.Repositories.Expressions/ExpressionTextSections/ExpressionTextSectionRepository.cs
+++ b/api/ExpressedRealms.Repositories.Expressions/ExpressionTextSections/ExpressionTextSectionRepository.cs
@@ -92,6 +92,10 @@ internal sealed class ExpressionTextSectionRepository(
         var result = await createExpressionDtoValidator.ValidateAsync(dto, cancellationToken);
         if (!result.IsValid)
             return Result.Fail(new FluentValidationFailure(result.ToDictionary()));
+        
+        var nextPlaceOnList = await context.ExpressionSections.AsNoTracking()
+            .Where(x => x.ExpressionId == dto.ExpressionId && x.ParentId == dto.ParentId)
+            .CountAsync();
 
         var expression = new ExpressionSection()
         {
@@ -100,6 +104,7 @@ internal sealed class ExpressionTextSectionRepository(
             ExpressionId = dto.ExpressionId,
             SectionTypeId = dto.SectionTypeId,
             ParentId = dto.ParentId,
+            OrderIndex = nextPlaceOnList + 1,
         };
 
         context.ExpressionSections.Add(expression);

--- a/client/src/components/expressions/CreateExpressionSection.vue
+++ b/client/src/components/expressions/CreateExpressionSection.vue
@@ -23,7 +23,8 @@ const props = defineProps({
     type: Number
   },
   addExpressionHeader:{
-    type: Boolean
+    type: Boolean,
+    value: false
   }
 });
 
@@ -58,7 +59,12 @@ function loadSectionInfo(){
   if(!showOptionLoader.value) return; // Don't load in 2nd time
   axios.get(`/expressionSubSections/${expressionInfo.currentExpressionId}/0/options`)
       .then(async (response) => {
-        sectionTypeOptions.value = response.data.sectionTypes;
+        if(!props.addExpressionHeader) {
+          sectionTypeOptions.value = response.data.sectionTypes.filter(sectionType => sectionType.name.toLowerCase() !== "expression");
+        }
+        else{
+          sectionTypeOptions.value = response.data.sectionTypes;
+        }
         showOptionLoader.value = false;
 
         if(props.addExpressionHeader) {

--- a/client/src/components/expressions/EditExpressionSection.vue
+++ b/client/src/components/expressions/EditExpressionSection.vue
@@ -72,8 +72,13 @@ function loadSectionInfo(){
   axios.get(`/expressionSubSections/${expressionInfo.currentExpressionId}/${props.sectionInfo.id}/options`)
       .then(async (response) => {
 
-        sectionTypeOptions.value = response.data.sectionTypes;
-
+        if(!props.isHeaderSection) {
+          sectionTypeOptions.value = response.data.sectionTypes.filter(sectionType => sectionType.name.toLowerCase() !== "expression");
+        }
+        else{
+          sectionTypeOptions.value = response.data.sectionTypes;
+        }
+        
         axios.get(`/expressionSubSections/${expressionInfo.currentExpressionId}/${props.sectionInfo.id}`)
             .then(async (json) => {
               name.value = json.data.name;
@@ -207,7 +212,7 @@ const deleteExpression = (event) => {
     <div class="mb-2 fix-wrapping" v-html="props.sectionInfo.content" />
   </div>
   <div v-if="showCreate && showEdit">
-    <CreateExpressionSection :parent-id="props.sectionInfo.id" :add-expression-header="true" @cancel-event="toggleCreate" @added-section="passThroughAddedSection()" />
+    <CreateExpressionSection :parent-id="props.sectionInfo.id" @cancel-event="toggleCreate" @added-section="passThroughAddedSection()" />
   </div>
 </template>
 


### PR DESCRIPTION
Section type should no longer show "Expression", as that's now being used for the header portion
When adding sections, it will now add to the bottom of the section group, not the top