### PR TITLE
You are unable to Add Powers in Aeternari

### DIFF
--- a/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerCreate/CreatePowerModelValidator.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerCreate/CreatePowerModelValidator.cs
@@ -41,7 +41,7 @@ public class CreatePowerModelValidator : AbstractValidator<CreatePowerModel>
             .MustAsync(
                 async (categories, cancellationToken) =>
                 {
-                    return await dbContext.PowerLevels.AnyAsync(
+                    return await dbContext.PowerCategories.AnyAsync(
                         x => categories!.Contains(x.Id),
                         cancellationToken
                     );


### PR DESCRIPTION
Turns out that the Category validation check was checking against power level id's, not category id's

This wasn't an issue until after we added more categories, as categories originally only had 4 options, which matched the 4 options in power levels