### PR TITLE
You are unable to Edit powers for Aternari

### DIFF
--- a/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerEdit/EditPowerModelValidator.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerEdit/EditPowerModelValidator.cs
@@ -52,7 +52,7 @@ public class EditPowerModelValidator : AbstractValidator<EditPowerModel>
             .MustAsync(
                 async (categories, cancellationToken) =>
                 {
-                    return await dbContext.PowerLevels.AnyAsync(
+                    return await dbContext.PowerCategories.AnyAsync(
                         x => categories!.Contains(x.Id),
                         cancellationToken
                     );


### PR DESCRIPTION
Same issue as add, category validation check was checking against power level id's, not category id's

This wasn't an issue until after we added more categories, as categories originally only had 4 options, which matched the 4 options in power levels