### PR TITLE
Rearrange Character Sheet - #457

### DIFF
--- a/client/src/FormWrappers/FormInputTextWrapper.vue
+++ b/client/src/FormWrappers/FormInputTextWrapper.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 
 import InputText from "primevue/inputtext";
-import {computed, watch, ref} from "vue";
+import {computed} from "vue";
 import Skeleton from 'primevue/skeleton';
 import type {FormField} from "@/FormWrappers/Interfaces/FormField";
 

--- a/client/src/components/characters/character/CharacterDetailTile.vue
+++ b/client/src/components/characters/character/CharacterDetailTile.vue
@@ -32,10 +32,12 @@ function toggleEdit() {
 <template>
   <Card v-if="!showEdit" class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="max-width: 30em">
     <template #content>
-        <h1 class="mt-0 pt-0">{{name}}</h1>
-        <div>{{expression}}</div>
-        <div>{{faction?.name ?? 'No Faction'}}</div>
-        <Button class="float-end" label="Edit" @click="toggleEdit" />
+      <h1 class="mt-0 pt-0">
+        {{ name }}
+      </h1>
+      <div>{{ expression }}</div>
+      <div>{{ faction?.name ?? 'No Faction' }}</div>
+      <Button class="float-end" label="Edit" @click="toggleEdit" />
     </template>
   </Card>
   <EditCharacterDetails v-else @close-dialog="toggleEdit" />

--- a/client/src/components/characters/character/CharacterDetailTile.vue
+++ b/client/src/components/characters/character/CharacterDetailTile.vue
@@ -5,6 +5,8 @@ import {onMounted, ref} from "vue";
 import { useRoute } from 'vue-router'
 const route = useRoute()
 import {characterStore} from "@/components/characters/character/stores/characterStore";
+import Button from "primevue/button";
+import EditCharacterDetails from "@/components/characters/character/EditCharacterDetails.vue";
 const characterInfo = characterStore();
 
 onMounted(async () =>{
@@ -19,15 +21,22 @@ onMounted(async () =>{
 const name = ref("");
 const faction = ref("");
 const expression = ref("");
+const showEdit = ref(false);
+
+function toggleEdit() {
+  showEdit.value = !showEdit.value;
+}
 
 </script>
 
 <template>
-  <Card class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 325px">
+  <Card v-if="!showEdit" class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 325px">
     <template #content>
         <h1 class="mt-0 pt-0">{{name}}</h1>
         <div>{{expression}}</div>
         <div>{{faction?.name ?? 'No Faction'}}</div>
+        <Button class="float-end" label="Edit" @click="toggleEdit" />
     </template>
   </Card>
+  <EditCharacterDetails v-else @close-dialog="toggleEdit" />
 </template>

--- a/client/src/components/characters/character/CharacterDetailTile.vue
+++ b/client/src/components/characters/character/CharacterDetailTile.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+
+import Card from "primevue/card";
+import {onMounted, ref} from "vue";
+import { useRoute } from 'vue-router'
+const route = useRoute()
+import {characterStore} from "@/components/characters/character/stores/characterStore";
+const characterInfo = characterStore();
+
+onMounted(async () =>{
+  await characterInfo.getCharacterDetails(Number(route.params.id))
+      .then(() => {
+        name.value = characterInfo.name;
+        expression.value = characterInfo.expression;
+        faction.value = characterInfo.faction;
+      });
+});
+
+const name = ref("");
+const faction = ref("");
+const expression = ref("");
+
+</script>
+
+<template>
+  <Card class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 325px">
+    <template #content>
+        <h1 class="mt-0 pt-0">{{name}}</h1>
+        <div>{{expression}}</div>
+        <div>{{faction?.name ?? 'No Faction'}}</div>
+    </template>
+  </Card>
+</template>

--- a/client/src/components/characters/character/CharacterDetailTile.vue
+++ b/client/src/components/characters/character/CharacterDetailTile.vue
@@ -30,7 +30,7 @@ function toggleEdit() {
 </script>
 
 <template>
-  <Card v-if="!showEdit" class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 325px">
+  <Card v-if="!showEdit" class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="max-width: 30em">
     <template #content>
         <h1 class="mt-0 pt-0">{{name}}</h1>
         <div>{{expression}}</div>

--- a/client/src/components/characters/character/EditCharacter.vue
+++ b/client/src/components/characters/character/EditCharacter.vue
@@ -36,9 +36,6 @@ import TrackableProficiencies from "@/components/characters/character/proficienc
       <TabList>
         <Tab value="0">Proficiencies</Tab>
         <Tab value="1">Skills</Tab>
-        <Tab value="2">Knowledges</Tab>
-        <Tab value="3">Powers</Tab>
-        <Tab value="4">Advantages / Disadvantages / Mixed Blessings</Tab>
       </TabList>
       <TabPanels class="p-2 p-md-3">
         <TabPanel value="0">
@@ -46,24 +43,6 @@ import TrackableProficiencies from "@/components/characters/character/proficienc
         </TabPanel>
         <TabPanel value="1">
           <SkillTile />
-        </TabPanel>
-        <TabPanel value="2">
-          <p class="m-0">
-            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim
-            ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
-          </p>
-        </TabPanel>
-        <TabPanel value="3">
-          <p class="m-0">
-            At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa
-            qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
-          </p>
-        </TabPanel>
-        <TabPanel value="4">
-          <p class="m-0">
-            At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa
-            qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
-          </p>
         </TabPanel>
       </TabPanels>
     </Tabs>

--- a/client/src/components/characters/character/EditCharacter.vue
+++ b/client/src/components/characters/character/EditCharacter.vue
@@ -9,7 +9,6 @@ import TabPanel from 'primevue/tabpanel';
 import Card from "primevue/card";
 import SmallStatDisplay from "@/components/characters/character/SmallStatDisplay.vue";
 import SkillTile from "@/components/characters/character/skills/SkillTile.vue";
-import EditCharacterDetails from "@/components/characters/character/EditCharacterDetails.vue";
 import DataTable from "primevue/datatable";
 
 import ProficiencyTableTile from "@/components/characters/character/proficiency/ProficiencyTableTile.vue";
@@ -79,7 +78,7 @@ import TrackableProficiencies from "@/components/characters/character/proficienc
 }
 
 .center-content {
-  max-width: 1000px;
+  max-width: 72em;
   margin: 0 auto !important;
 }
 

--- a/client/src/components/characters/character/EditCharacter.vue
+++ b/client/src/components/characters/character/EditCharacter.vue
@@ -15,7 +15,6 @@ import ProficiencyTableTile from "@/components/characters/character/proficiency/
 import CharacterDetailTile from "@/components/characters/character/CharacterDetailTile.vue";
 import TrackableProficiencies from "@/components/characters/character/proficiency/TrackableProficiencies.vue";
 
-
 </script>
 
 <template>
@@ -30,12 +29,16 @@ import TrackableProficiencies from "@/components/characters/character/proficienc
       </template>
     </Card>
     
-    <TrackableProficiencies></TrackableProficiencies>
+    <TrackableProficiencies />
     
     <Tabs value="0" class="w-100" scrollable>
       <TabList>
-        <Tab value="0">Proficiencies</Tab>
-        <Tab value="1">Skills</Tab>
+        <Tab value="0">
+          Proficiencies
+        </Tab>
+        <Tab value="1">
+          Skills
+        </Tab>
       </TabList>
       <TabPanels class="p-2 p-md-3">
         <TabPanel value="0">

--- a/client/src/components/characters/character/EditCharacter.vue
+++ b/client/src/components/characters/character/EditCharacter.vue
@@ -1,25 +1,21 @@
 <script setup lang="ts">
 
+import Tabs from 'primevue/tabs';
+import TabList from 'primevue/tablist';
+import Tab from 'primevue/tab';
+import TabPanels from 'primevue/tabpanels';
+import TabPanel from 'primevue/tabpanel';
+
 import Card from "primevue/card";
-import { ref } from "vue";
 import SmallStatDisplay from "@/components/characters/character/SmallStatDisplay.vue";
-import Breadcrumb from 'primevue/breadcrumb';
-import SkeletonWrapper from "@/FormWrappers/SkeletonWrapper.vue";
 import SkillTile from "@/components/characters/character/skills/SkillTile.vue";
 import EditCharacterDetails from "@/components/characters/character/EditCharacterDetails.vue";
 import DataTable from "primevue/datatable";
 
-import {characterStore} from "@/components/characters/character/stores/characterStore";
 import ProficiencyTableTile from "@/components/characters/character/proficiency/ProficiencyTableTile.vue";
-const characterInfo = characterStore();
+import CharacterDetailTile from "@/components/characters/character/CharacterDetailTile.vue";
+import TrackableProficiencies from "@/components/characters/character/proficiency/TrackableProficiencies.vue";
 
-const items = ref([
-  { label: characterInfo.name },
-]);
-const home = ref({
-  icon: 'pi pi-home',
-  route: '/characters'
-});
 
 </script>
 
@@ -27,31 +23,51 @@ const home = ref({
   <div class="d-none">
     <DataTable />
   </div>
-  <SkeletonWrapper :show-skeleton="characterInfo.isLoading" width="1em" height="1em">
-    <Breadcrumb :home="home" :model="items" class="m-3">
-      <template #item="{ item, props }">
-        <router-link v-if="item.route" v-slot="{ href, navigate }" :to="item.route" custom>
-          <a :href="href" v-bind="props.action" @click="navigate">
-            <span class="pi pi-home text-color" />
-            <span class="text-primary font-semibold">{{ item.label }}</span>
-          </a>
-        </router-link>
-        <a v-else :href="item.url" :target="item.target" v-bind="props.action">
-          <span class="text-color">{{ characterInfo.name }}</span>
-        </a>
-      </template>
-    </Breadcrumb>
-  </SkeletonWrapper>
-  <div class="flex flex-xs-column flex-sm-column flex-lg-row flex-md-row gap-3 m-1 m-sm-3 m-md-3 m-lg-3 m-xl-3 flex-wrap">
-    <EditCharacterDetails />
-    <Card class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch">
+  <div class="flex flex-xs-column flex-sm-column flex-lg-row flex-md-row gap-3 m-1 m-sm-3 m-md-3 m-lg-3 m-xl-3 flex-wrap center-content">
+    <CharacterDetailTile />
+    <Card class="align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch">
       <template #content>
         <SmallStatDisplay />
       </template>
     </Card>
-
-    <SkillTile />
-    <ProficiencyTableTile />
+    
+    <TrackableProficiencies></TrackableProficiencies>
+    
+    <Tabs value="0" class="w-100" scrollable>
+      <TabList>
+        <Tab value="0">Proficiencies</Tab>
+        <Tab value="1">Skills</Tab>
+        <Tab value="2">Knowledges</Tab>
+        <Tab value="3">Powers</Tab>
+        <Tab value="4">Advantages / Disadvantages / Mixed Blessings</Tab>
+      </TabList>
+      <TabPanels class="p-2 p-md-3">
+        <TabPanel value="0">
+          <ProficiencyTableTile />
+        </TabPanel>
+        <TabPanel value="1">
+          <SkillTile />
+        </TabPanel>
+        <TabPanel value="2">
+          <p class="m-0">
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim
+            ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+          </p>
+        </TabPanel>
+        <TabPanel value="3">
+          <p class="m-0">
+            At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa
+            qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
+          </p>
+        </TabPanel>
+        <TabPanel value="4">
+          <p class="m-0">
+            At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa
+            qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
+          </p>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
   </div>
 </template>
 
@@ -61,4 +77,10 @@ const home = ref({
     flex-direction: column !important;
   }
 }
+
+.center-content {
+  max-width: 1000px;
+  margin: 0 auto !important;
+}
+
 </style>

--- a/client/src/components/characters/character/EditCharacterDetails.vue
+++ b/client/src/components/characters/character/EditCharacterDetails.vue
@@ -74,7 +74,7 @@ let expressionRedirectURL = computed(() => {
 </script>
 
 <template>
-  <Card class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 325px">
+  <Card class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="max-width: 30em">
     <template #content>
       <form @submit="onSubmit">
         <InputTextWrapper v-model="name" field-name="Name" :error-text="errors.name" :show-skeleton="characterInfo.isLoading" @change="onSubmit" />

--- a/client/src/components/characters/character/EditCharacterDetails.vue
+++ b/client/src/components/characters/character/EditCharacterDetails.vue
@@ -14,7 +14,12 @@ import DropdownInfoWrapper from "@/FormWrappers/DropdownInfoWrapper.vue";
 import {makeIdSafe} from "@/utilities/stringUtilities";
 import type {Faction} from "@/components/characters/character/interfaces/Faction";
 import {characterStore} from "@/components/characters/character/stores/characterStore";
+import Button from "primevue/button";
 const characterInfo = characterStore();
+
+const emit = defineEmits<{
+  closeDialog: []
+}>();
 
 onMounted(async () =>{
   await characterInfo.getCharacterDetails(Number(route.params.id))
@@ -69,7 +74,7 @@ let expressionRedirectURL = computed(() => {
 </script>
 
 <template>
-  <Card class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 390px">
+  <Card class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 325px">
     <template #content>
       <form @submit="onSubmit">
         <InputTextWrapper v-model="name" field-name="Name" :error-text="errors.name" :show-skeleton="characterInfo.isLoading" @change="onSubmit" />
@@ -79,6 +84,7 @@ let expressionRedirectURL = computed(() => {
           :show-skeleton="characterInfo.isLoading" :redirect-url="expressionRedirectURL" @change="onSubmit"
         />
         <TextAreaWrapper v-model="background" field-name="Background" :error-text="errors.background" :show-skeleton="characterInfo.isLoading" @change="onSubmit" />
+        <Button class="float-end" label="close" @click="emit('closeDialog')" />
       </form>
     </template>
   </Card>

--- a/client/src/components/characters/character/SmallStatDisplay.vue
+++ b/client/src/components/characters/character/SmallStatDisplay.vue
@@ -35,7 +35,7 @@ function updateStat(level:number, bonus:number){
 </script>
 
 <template>
-  <div class="flex flex-wrap justify-content-center column-gap-3 row-gap-3" style="max-width: 350px">
+  <div class="flex flex-wrap justify-content-center column-gap-3 row-gap-3 w-100">
     <div v-for="stat in stats" v-if="!showDetails" :key="stat.statTypeId" class="align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch m-0 p-0">
       <Fieldset class="statBlock mb-3" style="cursor: pointer;" @click="showDetailedStat(stat.statTypeId)">
         <template #legend>

--- a/client/src/components/characters/character/proficiency/ProficiencyTableTile.vue
+++ b/client/src/components/characters/character/proficiency/ProficiencyTableTile.vue
@@ -19,7 +19,6 @@ const profStore = proficiencyStore();
 const types = computed(() => [
   { name: "Offensive Proficiencies", items: profStore.offensive },
   { name: "Defensive Proficiencies", items: profStore.defensive },
-  { name: "Secondary Proficiencies", items: profStore.secondary }
 ]);
 
 onMounted(() =>{

--- a/client/src/components/characters/character/proficiency/ProficiencyTableTile.vue
+++ b/client/src/components/characters/character/proficiency/ProficiencyTableTile.vue
@@ -31,7 +31,9 @@ onMounted(() =>{
   <div class="d-inline-flex flex-wrap justify-content-center column-gap-3 row-gap-1 w-100">
     <Panel v-for="type in types" :key="type.name" class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 25em">
       <template #header>
-        <h3 class="pb-0 mb-0 mt-0 pt-0">{{ type.name }}</h3>
+        <h3 class="pb-0 mb-0 mt-0 pt-0">
+          {{ type.name }}
+        </h3>
       </template>
       <Accordion :value="openItems" multiple :lazy="true" expand-icon="pi pi-info-circle" collapse-icon="pi pi-times-circle">
         <AccordionPanel v-for="proficiency in type.items" :key="proficiency.id" :value="proficiency.id">

--- a/client/src/components/characters/character/proficiency/ProficiencyTableTile.vue
+++ b/client/src/components/characters/character/proficiency/ProficiencyTableTile.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 
-import Card from "primevue/card";
 import {computed, onMounted, ref} from "vue";
 import { useRoute } from 'vue-router'
 import {proficiencyStore} from "@/components/characters/character/proficiency/stores/proficiencyStore";
+import Panel from "primevue/panel";
 
 const route = useRoute()
 
@@ -28,62 +28,60 @@ onMounted(() =>{
 </script>
 
 <template>
-  <Card class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch w-100 max-width">
-    <template #content>
-      <div class="d-flex flex-md-row flex-column">
-        <div v-for="type in types" :key="type.name" class="col">
-          <h3>{{ type.name }}</h3>
-          <Accordion :value="openItems" multiple :lazy="true" expand-icon="pi pi-info-circle" collapse-icon="pi pi-times-circle">
-            <AccordionPanel v-for="proficiency in type.items" :key="proficiency.id" :value="proficiency.id">
-              <AccordionHeader>
-                <div class="d-flex justify-content-between w-100 pr-3">
-                  <div>{{ proficiency.name }}</div>
-                  <div class="text-right">
-                    {{ proficiency.value }}
-                  </div>
-                </div>
-              </AccordionHeader>
-              <AccordionContent>
-                <div class="p-datatable p-component p-datatable-striped">
-                  <div class="p-datatable-table-container">
-                    <table class="w-100 p-datatable-table">
-                      <!-- Table header -->
-                      <thead class="p-datatable-thead">
-                        <tr>
-                          <th class="p-datatable-header-cell">
-                            Source
-                          </th>
-                          <th class="p-datatable-header-cell">
-                            Details
-                          </th>
-                          <th class="p-datatable-header-cell">
-                            Bonus
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody class="p-datatable-tbody">
-                        <tr v-for="(modifier, index) in proficiency.appliedModifiers" :key="index" :class="index % 2 === 0 ? 'p-row-even' : 'p-row-odd'">
-                          <td>
-                            {{ modifier.name }}
-                          </td>
-                          <td>
-                            {{ modifier.message }}
-                          </td>
-                          <td class="text-right">
-                            {{ modifier.value >= 0 ? '+' : '' }}{{ modifier.value }}
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
-              </AccordionContent>
-            </AccordionPanel>
-          </Accordion>
-        </div>
-      </div>
-    </template>
-  </Card>
+  <div class="d-inline-flex flex-wrap justify-content-center column-gap-3 row-gap-1 w-100">
+    <Panel v-for="type in types" :key="type.name" class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 25em">
+      <template #header>
+        <h3 class="pb-0 mb-0 mt-0 pt-0">{{ type.name }}</h3>
+      </template>
+      <Accordion :value="openItems" multiple :lazy="true" expand-icon="pi pi-info-circle" collapse-icon="pi pi-times-circle">
+        <AccordionPanel v-for="proficiency in type.items" :key="proficiency.id" :value="proficiency.id">
+          <AccordionHeader>
+            <div class="d-flex justify-content-between w-100 pr-3">
+              <div>{{ proficiency.name }}</div>
+              <div class="text-right">
+                {{ proficiency.value }}
+              </div>
+            </div>
+          </AccordionHeader>
+          <AccordionContent>
+            <div class="p-datatable p-component p-datatable-striped">
+              <div class="p-datatable-table-container">
+                <table class="w-100 p-datatable-table">
+                  <!-- Table header -->
+                  <thead class="p-datatable-thead">
+                    <tr>
+                      <th class="p-datatable-header-cell">
+                        Source
+                      </th>
+                      <th class="p-datatable-header-cell">
+                        Details
+                      </th>
+                      <th class="p-datatable-header-cell">
+                        Bonus
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody class="p-datatable-tbody">
+                    <tr v-for="(modifier, index) in proficiency.appliedModifiers" :key="index" :class="index % 2 === 0 ? 'p-row-even' : 'p-row-odd'">
+                      <td>
+                        {{ modifier.name }}
+                      </td>
+                      <td>
+                        {{ modifier.message }}
+                      </td>
+                      <td class="text-right">
+                        {{ modifier.value >= 0 ? '+' : '' }}{{ modifier.value }}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </AccordionContent>
+        </AccordionPanel>
+      </Accordion>
+    </Panel>
+  </div>
 </template>
 
 <style>
@@ -92,5 +90,11 @@ onMounted(() =>{
     width: 100%;
     max-width: 75em
   }
+}
+
+.p-panel-header{
+  background: var(--p-panel-background) !important;
+  border-bottom: 0px !important;
+  padding: 1.5em 1.5em 0em !important;
 }
 </style>

--- a/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
+++ b/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
@@ -19,7 +19,7 @@ onMounted(() =>{
     <template #content>
       <div class="d-inline-flex flex-wrap gap-1 justify-content-center">
         <div v-for="proficiency in profStore.secondary" :key="proficiency.id" :value="proficiency.id" class="vitality-tile p-2 m-md-2 p-md-3">
-          <div>{{ proficiency.name }}</div>
+          <div class="pb-2">{{ proficiency.name }}</div>
           <InputNumber v-model="proficiency.value" :suffix="' / ' + proficiency.maxValue" 
                        :min="0" :max="proficiency.maxValue" 
                        showButtons buttonLayout="horizontal"

--- a/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
+++ b/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
@@ -23,7 +23,7 @@ onMounted(() =>{
           <InputNumber v-model="proficiency.value" :suffix="' / ' + proficiency.maxValue" 
                        :min="0" :max="proficiency.maxValue" 
                        showButtons buttonLayout="horizontal"
-                       fluid style="width: 9.5em" class="text-center"
+                       fluid style="width: 10em" class="text-center"
           >
             <template #incrementbuttonicon>
               <span class="pi pi-plus" />

--- a/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
+++ b/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+
+import Card from "primevue/card";
+import { onMounted } from "vue";
+import { useRoute } from 'vue-router'
+import {proficiencyStore} from "@/components/characters/character/proficiency/stores/proficiencyStore";
+import InputNumber from 'primevue/inputnumber';
+const route = useRoute()
+const profStore = proficiencyStore();
+
+onMounted(() =>{
+  profStore.getUpdateProficiencies(route.params.id);
+});
+
+</script>
+
+<template>
+  <Card class="p-1 p-md-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch w-100 max-width">
+    <template #content>
+      <div class="d-inline-flex flex-wrap gap-1 justify-content-center">
+        <div v-for="proficiency in profStore.secondary" :key="proficiency.id" :value="proficiency.id" class="vitality-tile p-2 m-md-2 p-md-3">
+          <div>{{ proficiency.name }}</div>
+          <InputNumber v-model="proficiency.value" :suffix="' / ' + proficiency.maxValue" 
+                       :min="0" :max="proficiency.maxValue" 
+                       showButtons buttonLayout="horizontal"
+                       fluid style="width: 9.5em" class="text-center"
+          >
+            <template #incrementbuttonicon>
+              <span class="pi pi-plus" />
+            </template>
+            <template #decrementbuttonicon>
+              <span class="pi pi-minus" />
+            </template>
+          </InputNumber>
+        </div>
+      </div>
+    </template>
+  </Card>
+</template>
+
+<style>
+@media(min-width: 768px){
+  .max-width {
+    width: 100%;
+    max-width: 75em
+  }
+}
+
+.vitality-tile{
+  border: 1px solid var(--p-fieldset-border-color);
+  border-radius: var(--p-fieldset-border-radius);
+}
+
+.p-card-body{
+  padding: 0;
+}
+
+ .p-inputnumber-input{
+   text-align: center;
+ }
+
+</style>

--- a/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
+++ b/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
@@ -15,7 +15,7 @@ onMounted(() =>{
 </script>
 
 <template>
-  <Card class="p-1 p-md-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch w-100 max-width">
+  <Card class="custom-tile p-1 p-md-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch w-100 max-width">
     <template #content>
       <div class="d-inline-flex flex-wrap gap-1 justify-content-center">
         <div v-for="proficiency in profStore.secondary" :key="proficiency.id" :value="proficiency.id" class="vitality-tile p-2 m-md-2 p-md-3">
@@ -44,6 +44,10 @@ onMounted(() =>{
     width: 100%;
     max-width: 75em
   }
+  .custom-tile .p-card-body {
+    padding-left: inherit !important;
+    padding-right: inherit !important;
+  }
 }
 
 .vitality-tile{
@@ -51,8 +55,9 @@ onMounted(() =>{
   border-radius: var(--p-fieldset-border-radius);
 }
 
-.p-card-body{
-  padding: 0;
+.custom-tile .p-card-body{
+  padding-left: 0 !important;
+  padding-right: 0 !important;
 }
 
  .p-inputnumber-input{

--- a/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
+++ b/client/src/components/characters/character/proficiency/TrackableProficiencies.vue
@@ -19,11 +19,14 @@ onMounted(() =>{
     <template #content>
       <div class="d-inline-flex flex-wrap gap-1 justify-content-center">
         <div v-for="proficiency in profStore.secondary" :key="proficiency.id" :value="proficiency.id" class="vitality-tile p-2 m-md-2 p-md-3">
-          <div class="pb-2">{{ proficiency.name }}</div>
-          <InputNumber v-model="proficiency.value" :suffix="' / ' + proficiency.maxValue" 
-                       :min="0" :max="proficiency.maxValue" 
-                       showButtons buttonLayout="horizontal"
-                       fluid style="width: 10em" class="text-center"
+          <div class="pb-2">
+            {{ proficiency.name }}
+          </div>
+          <InputNumber
+            v-model="proficiency.value" :suffix="' / ' + proficiency.maxValue" 
+            :min="0" :max="proficiency.maxValue" 
+            show-buttons button-layout="horizontal"
+            fluid style="width: 10em" class="text-center"
           >
             <template #incrementbuttonicon>
               <span class="pi pi-plus" />

--- a/client/src/components/characters/character/proficiency/stores/proficiencyStore.ts
+++ b/client/src/components/characters/character/proficiency/stores/proficiencyStore.ts
@@ -19,6 +19,10 @@ export const proficiencyStore =
                         this.offensive = response.data.proficiencies.filter(x => x.type === "Offensive");
                         this.defensive = response.data.proficiencies.filter(x => x.type === "Defensive");
                         this.secondary = response.data.proficiencies.filter(x => x.type === "Secondary");
+                        
+                        this.secondary.map(x => {
+                            x.maxValue = x.value;
+                        });
                         this.isLoading = false;
                     })
             }

--- a/client/src/components/characters/character/proficiency/types.ts
+++ b/client/src/components/characters/character/proficiency/types.ts
@@ -5,6 +5,7 @@ interface ProficienciesDto {
     appliedModifiers: ModifierDescription[];
     correspondingId: number; // byte maps to number in TypeScript
     value: number;
+    maxValue: number;
     id: number;
     type: string;
 }

--- a/client/src/components/characters/character/skills/SkillTile.vue
+++ b/client/src/components/characters/character/skills/SkillTile.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 
 import axios from "axios";
-import Card from "primevue/card";
+import Panel from "primevue/panel";
 import {computed, onMounted, ref, type Ref} from "vue";
 import { useRoute } from 'vue-router'
 const route = useRoute()
@@ -17,7 +17,6 @@ import {skillStore} from "@/components/characters/character/skills/Stores/skillS
 
 const offensiveSkills:Ref<Array<CharacterSkillsResponse>> = ref([]);
 const defensiveSkills:Ref<Array<CharacterSkillsResponse>> = ref([]);
-const showEdit = ref(false);
 const maxXP = 28;
 const appliedXp = ref(0);
 const skillInfo = skillStore();
@@ -46,24 +45,24 @@ function getEditOptions() {
 </script>
 
 <template>
-  <Card v-for="skillType in skillTypes" class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 25em">
-    <template #title>
-      <div class="row">
-        <div class="col">
-          {{ skillType.name }}
+  <div class="d-inline-flex flex-wrap justify-content-center column-gap-3 row-gap-1 w-100">
+    <Panel v-for="skillType in skillTypes" class="mb-3 align-self-lg-start align-self-md-start align-self-xl-start align-self-sm-stretch" style="width: 25em">
+      <template #header>
+        <div class="row">
+          <h3 class="col pb-0 mb-0 mt-0 pt-0">
+            {{ skillType.name }}
+          </h3>
+          <div v-if="skillInfo.showExperience" class="col text-right">
+            {{ remainingXP }} EXP
+          </div>
         </div>
-        <div v-if="skillInfo.showExperience" class="col text-right">
-          {{ remainingXP }} EXP
-        </div>
-      </div>
-    </template>
-    <template #content>
+      </template>
       <Accordion :value="openItems" multiple :lazy="true" expand-icon="pi pi-info-circle" collapse-icon="pi pi-times-circle">
         <AccordionPanel v-for="skill in skillType.skills" :key="skill.name" :value="skill.skillTypeId">
-          <AccordionHeader>  
-            <div class="d-flex justify-content-between w-100 pr-3">
+          <AccordionHeader>
+            <div class="d-flex justify-content-between w-100 pr-3 flex-column flex-md-row">
               <div>{{ skill.name }}</div>
-              <div class="text-right">
+              <div class="md:text-right mt-md-0 mt-2">
                 {{ skill.levelName }} ({{ skill.levelNumber }})
               </div>
             </div>
@@ -76,6 +75,16 @@ function getEditOptions() {
           </AccordionContent>
         </AccordionPanel>
       </Accordion>
-    </template>
-  </Card>
+    </Panel>
+  </div>
+  
 </template>
+
+<style>
+ .p-panel-header{
+   background: var(--p-panel-background);
+   border-bottom: 0px;
+   padding: 1.5em;
+   padding-bottom: 0em;
+ }
+</style>

--- a/client/src/components/characters/character/skills/SkillTile.vue
+++ b/client/src/components/characters/character/skills/SkillTile.vue
@@ -82,9 +82,8 @@ function getEditOptions() {
 
 <style>
  .p-panel-header{
-   background: var(--p-panel-background);
-   border-bottom: 0px;
-   padding: 1.5em;
-   padding-bottom: 0em;
+   background: var(--p-panel-background) !important;
+   border-bottom: 0px !important;
+   padding: 1.5em 1.5em 0em !important;
  }
 </style>

--- a/client/src/components/characters/character/skills/SkillTile.vue
+++ b/client/src/components/characters/character/skills/SkillTile.vue
@@ -77,7 +77,6 @@ function getEditOptions() {
       </Accordion>
     </Panel>
   </div>
-  
 </template>
 
 <style>


### PR DESCRIPTION
Editing Character Details now hidden behind edit button
Character will now show just the name, expression, and any faction information
Removed navigation bar, as the characters navigation menu item is good enough
Added all consumable proficiencies to the middle of the character sheet
 - This won't store the values, it's there for show for now

Added tab spot below the character, now houses proficiencies and skills
 - This will be expanded upon with other things, such as knowledges, powers, etc
 - For said sections, the card was converted into a panel