### PR TITLE
5x3 index report will no longer return 2x6 report

### DIFF
--- a/api/ExpressedRealms.Powers.Reporting/powerCards/PowerCardReport.cs
+++ b/api/ExpressedRealms.Powers.Reporting/powerCards/PowerCardReport.cs
@@ -28,10 +28,17 @@ public static class PowerCardReport
     public static MemoryStream GenerateSixUpPdf(List<PowerCardData> powerCards, bool isFiveByThree)
     {
         var singleTileDoc = GenerateReport(powerCards, isFiveByThree);
-        using var srcStream = new MemoryStream();
+        var srcStream = new MemoryStream();
         singleTileDoc.GeneratePdf(srcStream);
-        var pdfBytes = srcStream.ToArray();
 
+        if (isFiveByThree)
+        {
+            return srcStream;
+        }
+        
+        var pdfBytes = srcStream.ToArray();
+        srcStream.Dispose();
+        
         // 2) Load the PDF once as an XPdfForm and use PageNumber to draw specific pages.
         using var outDoc = new PdfDocument();
 


### PR DESCRIPTION
When I updated the 2x6 report with manual generation, I didn't short circuit it if it was supposed to be the individual tile page, such as fro the 2x6 report

Closes #546 