### PR TITLE
Delete Should Not Remove Prerequisites

### DIFF
--- a/api/ExpressedRealms.Powers.API/CharacterPowerEndpoints/GetAll/GetCharacterPowersEndpoint.cs
+++ b/api/ExpressedRealms.Powers.API/CharacterPowerEndpoints/GetAll/GetCharacterPowersEndpoint.cs
@@ -43,6 +43,7 @@ public static class GetCharacterPowersEndpoint
                                 IsPowerUse = y.IsPowerUse,
                                 Cost = y.Cost,
                                 UserNotes = y.UserNotes,
+                                RequiredPower = y.RequiredPower,
                                 Prerequisites = y.Prerequisites is not null
                                     ? new PrerequisiteDetailsResponse()
                                     {

--- a/api/ExpressedRealms.Powers.API/CharacterPowerEndpoints/SharedResponses/PowerResponse.cs
+++ b/api/ExpressedRealms.Powers.API/CharacterPowerEndpoints/SharedResponses/PowerResponse.cs
@@ -20,4 +20,5 @@ public class PowerResponse
     public int SortOrder { get; set; }
     public string? UserNotes { get; set; }
     public PrerequisiteDetailsResponse? Prerequisites { get; set; }
+    public bool RequiredPower { get; set; }
 }

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
@@ -120,15 +120,17 @@ internal sealed class CharacterPowerRepository(
     public async Task<List<int>> GetPowersThatArePrerequisites(int characterId)
     {
         var powerMappings = await context
-            .CharacterPowerMappings.Where(x => x.CharacterId == characterId)
+            .CharacterPowerMappings.AsNoTracking()
+            .Where(x => x.CharacterId == characterId)
             .Select(x => x.PowerId)
             .ToListAsync(token);
 
-        var prerequisitePowerIds = await context
-            .PowerPrerequisitePowers.Where(x => powerMappings.Contains(x.PowerId))
-            .Select(x => x.Prerequisite.PowerId)
+        var prereqs = await context.PowerPrerequisites.AsNoTracking()
+            .Where(x => powerMappings.Contains(x.PowerId))
+            .SelectMany(x => x.PrerequisitePowers.Select(y => y.PowerId).ToList())
+            .Distinct()
             .ToListAsync();
 
-        return prerequisitePowerIds;
+        return prereqs;
     }
 }

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
@@ -100,7 +100,7 @@ internal sealed class CharacterPowerRepository(
         // Already selected powers should not be added again
         return selectablePowers.Except(powerMappings).ToList();
     }
-    
+
     public async Task<bool> IsPowerPartOfPrerequisite(int characterId, int powerId)
     {
         // Get all the assigned powers
@@ -109,24 +109,23 @@ internal sealed class CharacterPowerRepository(
             .Select(x => x.PowerId)
             .ToListAsync(token);
 
-
-        var prerequisitePowerIds = await context.PowerPrerequisitePowers
-            .Where(x => x.PowerId == powerId)
+        var prerequisitePowerIds = await context
+            .PowerPrerequisitePowers.Where(x => x.PowerId == powerId)
             .Select(x => x.Prerequisite.PowerId)
             .ToListAsync();
 
         return prerequisitePowerIds.Intersect(powerMappings).Any();
     }
-    
+
     public async Task<List<int>> GetPowersThatArePrerequisites(int characterId)
     {
         var powerMappings = await context
             .CharacterPowerMappings.Where(x => x.CharacterId == characterId)
             .Select(x => x.PowerId)
             .ToListAsync(token);
-        
-        var prerequisitePowerIds = await context.PowerPrerequisitePowers
-            .Where(x => powerMappings.Contains(x.PowerId))
+
+        var prerequisitePowerIds = await context
+            .PowerPrerequisitePowers.Where(x => powerMappings.Contains(x.PowerId))
             .Select(x => x.Prerequisite.PowerId)
             .ToListAsync();
 

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
@@ -103,11 +103,6 @@ internal sealed class CharacterPowerRepository(
     
     public async Task<bool> IsPowerPartOfPrerequisite(int characterId, int powerId)
     {
-        var expressionId = await context
-            .Characters.Where(x => x.Id == characterId)
-            .Select(x => x.ExpressionId)
-            .FirstAsync(token);
-
         // Get all the assigned powers
         var powerMappings = await context
             .CharacterPowerMappings.Where(x => x.CharacterId == characterId)
@@ -121,5 +116,20 @@ internal sealed class CharacterPowerRepository(
             .ToListAsync();
 
         return prerequisitePowerIds.Intersect(powerMappings).Any();
+    }
+    
+    public async Task<List<int>> GetPowersThatArePrerequisites(int characterId)
+    {
+        var powerMappings = await context
+            .CharacterPowerMappings.Where(x => x.CharacterId == characterId)
+            .Select(x => x.PowerId)
+            .ToListAsync(token);
+        
+        var prerequisitePowerIds = await context.PowerPrerequisitePowers
+            .Where(x => powerMappings.Contains(x.PowerId))
+            .Select(x => x.Prerequisite.PowerId)
+            .ToListAsync();
+
+        return prerequisitePowerIds;
     }
 }

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
@@ -100,4 +100,26 @@ internal sealed class CharacterPowerRepository(
         // Already selected powers should not be added again
         return selectablePowers.Except(powerMappings).ToList();
     }
+    
+    public async Task<bool> IsPowerPartOfPrerequisite(int characterId, int powerId)
+    {
+        var expressionId = await context
+            .Characters.Where(x => x.Id == characterId)
+            .Select(x => x.ExpressionId)
+            .FirstAsync(token);
+
+        // Get all the assigned powers
+        var powerMappings = await context
+            .CharacterPowerMappings.Where(x => x.CharacterId == characterId)
+            .Select(x => x.PowerId)
+            .ToListAsync(token);
+
+
+        var prerequisitePowerIds = await context.PowerPrerequisitePowers
+            .Where(x => x.PowerId == powerId)
+            .Select(x => x.Prerequisite.PowerId)
+            .ToListAsync();
+
+        return prerequisitePowerIds.Intersect(powerMappings).Any();
+    }
 }

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/ICharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/ICharacterPowerRepository.cs
@@ -13,4 +13,5 @@ public interface ICharacterPowerRepository
     Task UpdateCharacterPowerMapping(CharacterPowerMapping characterPowerMapping);
     Task<bool> IsValidMapping(int id);
     Task<List<CharacterPowerInfo>> GetCharacterPowerMappingInfo(int characterId);
+    Task<bool> IsPowerPartOfPrerequisite(int characterId, int powerId);
 }

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/ICharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/ICharacterPowerRepository.cs
@@ -14,4 +14,5 @@ public interface ICharacterPowerRepository
     Task<bool> IsValidMapping(int id);
     Task<List<CharacterPowerInfo>> GetCharacterPowerMappingInfo(int characterId);
     Task<bool> IsPowerPartOfPrerequisite(int characterId, int powerId);
+    Task<List<int>> GetPowersThatArePrerequisites(int characterId);
 }

--- a/api/ExpressedRealms.Powers.UseCases.Tests.Unit/CharacterPower/DeletePowerFromCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Powers.UseCases.Tests.Unit/CharacterPower/DeletePowerFromCharacterUseCaseTests.cs
@@ -62,7 +62,7 @@ public class DeletePowerFromCharacterUseCaseTests
                 )
             )
             .Returns(_mapping);
-        
+
         A.CallTo(() =>
                 _mappingRepository.IsPowerPartOfPrerequisite(
                     _powerToCharacterModel.CharacterId,
@@ -153,7 +153,7 @@ public class DeletePowerFromCharacterUseCaseTests
             "The Mapping does not exist."
         );
     }
-    
+
     [Fact]
     public async Task ValidationFor_PowerId_WillFail_WhenMappingIsPartOfAPrerequisite()
     {

--- a/api/ExpressedRealms.Powers.UseCases.Tests.Unit/CharacterPower/DeletePowerFromCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Powers.UseCases.Tests.Unit/CharacterPower/DeletePowerFromCharacterUseCaseTests.cs
@@ -62,6 +62,14 @@ public class DeletePowerFromCharacterUseCaseTests
                 )
             )
             .Returns(_mapping);
+        
+        A.CallTo(() =>
+                _mappingRepository.IsPowerPartOfPrerequisite(
+                    _powerToCharacterModel.CharacterId,
+                    _powerToCharacterModel.PowerId
+                )
+            )
+            .Returns(false);
 
         var validator = new DeletePowerFromCharacterModelValidator(
             _characterRepository,
@@ -143,6 +151,24 @@ public class DeletePowerFromCharacterUseCaseTests
         result.MustHaveValidationError(
             nameof(DeletePowerFromCharacterModel.PowerId),
             "The Mapping does not exist."
+        );
+    }
+    
+    [Fact]
+    public async Task ValidationFor_PowerId_WillFail_WhenMappingIsPartOfAPrerequisite()
+    {
+        A.CallTo(() =>
+                _mappingRepository.IsPowerPartOfPrerequisite(
+                    _powerToCharacterModel.CharacterId,
+                    _powerToCharacterModel.PowerId
+                )
+            )
+            .Returns(true);
+        var result = await _useCase.ExecuteAsync(_powerToCharacterModel);
+
+        result.MustHaveValidationError(
+            nameof(DeletePowerFromCharacterModel.PowerId),
+            "The Power is Part of a Prerequisite."
         );
     }
 

--- a/api/ExpressedRealms.Powers.UseCases.Tests.Unit/CharacterPower/GetCharacterPowersCaseTests.cs
+++ b/api/ExpressedRealms.Powers.UseCases.Tests.Unit/CharacterPower/GetCharacterPowersCaseTests.cs
@@ -120,7 +120,7 @@ public class GetCharacterPowersUseCaseTests
 
         A.CallTo(() => _mappingRepository.GetCharacterPowerMappingInfo(model.CharacterId))
             .Returns(_powerInfo);
-        
+
         A.CallTo(() => _mappingRepository.GetPowersThatArePrerequisites(model.CharacterId))
             .Returns(_requiredIds);
 

--- a/api/ExpressedRealms.Powers.UseCases.Tests.Unit/CharacterPower/GetCharacterPowersCaseTests.cs
+++ b/api/ExpressedRealms.Powers.UseCases.Tests.Unit/CharacterPower/GetCharacterPowersCaseTests.cs
@@ -23,6 +23,7 @@ public class GetCharacterPowersUseCaseTests
     private readonly List<PowerPathToc> _dbModels;
 
     private readonly List<CharacterPowerInfo> _powerInfo;
+    private readonly List<int> _requiredIds = new List<int>() { 2 };
 
     public GetCharacterPowersUseCaseTests()
     {
@@ -100,7 +101,7 @@ public class GetCharacterPowersUseCaseTests
                             "Power 2duration",
                             "Power duration descr2iption"
                         ),
-                        Id = 1,
+                        Id = 2,
                         Category = new List<DetailedInformation>()
                         {
                             new DetailedInformation("Categor2y 1", "Cate2gory 1 description"),
@@ -119,6 +120,9 @@ public class GetCharacterPowersUseCaseTests
 
         A.CallTo(() => _mappingRepository.GetCharacterPowerMappingInfo(model.CharacterId))
             .Returns(_powerInfo);
+        
+        A.CallTo(() => _mappingRepository.GetPowersThatArePrerequisites(model.CharacterId))
+            .Returns(_requiredIds);
 
         var powerIds = _powerInfo.Select(x => x.PowerId).ToList();
         A.CallTo(() => _powerPathRepository.GetPowerPathAndPowers(powerIds)).Returns(_dbModels);
@@ -202,6 +206,7 @@ public class GetCharacterPowersUseCaseTests
                         Other = y.Other,
                         IsPowerUse = y.IsPowerUse,
                         Cost = y.Cost,
+                        RequiredPower = _requiredIds.Contains(y.Id),
                         UserNotes = _powerInfo.FirstOrDefault(z => z.PowerId == y.Id)?.UserNotes,
                         Prerequisites = y.Prerequisites is not null
                             ? new PrerequisiteDetailsReturnModel()

--- a/api/ExpressedRealms.Powers.UseCases/CharacterPower/Delete/DeletePowerFromCharacterModelValidator.cs
+++ b/api/ExpressedRealms.Powers.UseCases/CharacterPower/Delete/DeletePowerFromCharacterModelValidator.cs
@@ -34,5 +34,12 @@ internal sealed class DeletePowerFromCharacterModelValidator
             )
             .WithMessage("The Mapping does not exist.")
             .WithName(nameof(DeletePowerFromCharacterModel.PowerId));
+        
+        RuleFor(x => x)
+            .MustAsync(
+                async (x, y) => !await mappingRepository.IsPowerPartOfPrerequisite(x.CharacterId, x.PowerId)
+            )
+            .WithMessage("The Power is Part of a Prerequisite.")
+            .WithName(nameof(DeletePowerFromCharacterModel.PowerId));
     }
 }

--- a/api/ExpressedRealms.Powers.UseCases/CharacterPower/Delete/DeletePowerFromCharacterModelValidator.cs
+++ b/api/ExpressedRealms.Powers.UseCases/CharacterPower/Delete/DeletePowerFromCharacterModelValidator.cs
@@ -34,10 +34,11 @@ internal sealed class DeletePowerFromCharacterModelValidator
             )
             .WithMessage("The Mapping does not exist.")
             .WithName(nameof(DeletePowerFromCharacterModel.PowerId));
-        
+
         RuleFor(x => x)
             .MustAsync(
-                async (x, y) => !await mappingRepository.IsPowerPartOfPrerequisite(x.CharacterId, x.PowerId)
+                async (x, y) =>
+                    !await mappingRepository.IsPowerPartOfPrerequisite(x.CharacterId, x.PowerId)
             )
             .WithMessage("The Power is Part of a Prerequisite.")
             .WithName(nameof(DeletePowerFromCharacterModel.PowerId));

--- a/api/ExpressedRealms.Powers.UseCases/CharacterPower/Delete/DeletePowerFromCharacterUseCase.cs
+++ b/api/ExpressedRealms.Powers.UseCases/CharacterPower/Delete/DeletePowerFromCharacterUseCase.cs
@@ -26,8 +26,6 @@ internal sealed class DeletePowerFromCharacterUseCase(
             model.CharacterId,
             model.PowerId
         );
-        
-        
 
         mapping.SoftDelete();
 

--- a/api/ExpressedRealms.Powers.UseCases/CharacterPower/Delete/DeletePowerFromCharacterUseCase.cs
+++ b/api/ExpressedRealms.Powers.UseCases/CharacterPower/Delete/DeletePowerFromCharacterUseCase.cs
@@ -26,6 +26,8 @@ internal sealed class DeletePowerFromCharacterUseCase(
             model.CharacterId,
             model.PowerId
         );
+        
+        
 
         mapping.SoftDelete();
 

--- a/api/ExpressedRealms.Powers.UseCases/CharacterPower/GetPowers/GetCharacterPowersUseCase.cs
+++ b/api/ExpressedRealms.Powers.UseCases/CharacterPower/GetPowers/GetCharacterPowersUseCase.cs
@@ -32,6 +32,7 @@ internal sealed class GetCharacterPowersUseCase(
 
         var powerIds = powerMappingInfo.Select(x => x.PowerId).ToList();
         var powers = await powerPathRepository.GetPowerPathAndPowers(powerIds);
+        var requiredPowers = await mappingRepository.GetPowersThatArePrerequisites(model.CharacterId);
 
         return Result.Ok(
             powers
@@ -68,6 +69,7 @@ internal sealed class GetCharacterPowersUseCase(
                                     Powers = y.Prerequisites.Powers,
                                 }
                                 : null,
+                            RequiredPower = requiredPowers.Contains(y.Id)
                         })
                         .ToList(),
                 })

--- a/api/ExpressedRealms.Powers.UseCases/CharacterPower/GetPowers/GetCharacterPowersUseCase.cs
+++ b/api/ExpressedRealms.Powers.UseCases/CharacterPower/GetPowers/GetCharacterPowersUseCase.cs
@@ -32,7 +32,9 @@ internal sealed class GetCharacterPowersUseCase(
 
         var powerIds = powerMappingInfo.Select(x => x.PowerId).ToList();
         var powers = await powerPathRepository.GetPowerPathAndPowers(powerIds);
-        var requiredPowers = await mappingRepository.GetPowersThatArePrerequisites(model.CharacterId);
+        var requiredPowers = await mappingRepository.GetPowersThatArePrerequisites(
+            model.CharacterId
+        );
 
         return Result.Ok(
             powers
@@ -69,7 +71,7 @@ internal sealed class GetCharacterPowersUseCase(
                                     Powers = y.Prerequisites.Powers,
                                 }
                                 : null,
-                            RequiredPower = requiredPowers.Contains(y.Id)
+                            RequiredPower = requiredPowers.Contains(y.Id),
                         })
                         .ToList(),
                 })

--- a/api/ExpressedRealms.Powers.UseCases/CharacterPower/GetPowers/ReturnModels/PowerReturnModel.cs
+++ b/api/ExpressedRealms.Powers.UseCases/CharacterPower/GetPowers/ReturnModels/PowerReturnModel.cs
@@ -18,4 +18,5 @@ public class PowerReturnModel
     public int SortOrder { get; set; }
     public PrerequisiteDetailsReturnModel? Prerequisites { get; set; }
     public string? UserNotes { get; set; }
+    public bool RequiredPower { get; set; }
 }

--- a/api/ExpressedRealms.Server.Shared/ExpressedRealms.Server.Shared.csproj
+++ b/api/ExpressedRealms.Server.Shared/ExpressedRealms.Server.Shared.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ExpressedRealms.Shared.FeatureFlags\ExpressedRealms.Shared.FeatureFlags.csproj" />
     <ProjectReference Include="..\ExpressedRealms.Repositories.Shared\ExpressedRealms.Repositories.Shared.csproj" />
+    <ProjectReference Include="..\ExpressedRealms.Shared.UseCases\ExpressedRealms.Shared.UseCases.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentResults" Version="3.16.0" />

--- a/api/ExpressedRealms.Server.Shared/ResultOverrides.cs
+++ b/api/ExpressedRealms.Server.Shared/ResultOverrides.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using ExpressedRealms.Repositories.Shared.CommonFailureTypes;
+using ExpressedRealms.UseCases.Shared.CommonFailureTypes;
 using FluentResults;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;

--- a/client/src/components/characters/character/powers/PowerCard.vue
+++ b/client/src/components/characters/character/powers/PowerCard.vue
@@ -68,7 +68,7 @@ const openKnowledgeItems = ref([]);
           <template #title v-if="props.showEdit">
              <div class="d-flex flex-column flex-md-row align-self-center justify-content-end">
                <div class="p-0 m-0 d-inline-flex">
-                 <Button class="mr-2" severity="danger" label="Delete" @click="popups.deleteConfirmation($event, power.id)" />
+                 <Button v-if="power.requiredPower" class="mr-2" severity="danger" label="Delete" @click="popups.deleteConfirmation($event, power.id)" />
                  <Button class="float-end" label="Edit" @click="dialogs.showEditPower(power)" />
                </div>
              </div>

--- a/client/src/components/characters/character/powers/PowerCard.vue
+++ b/client/src/components/characters/character/powers/PowerCard.vue
@@ -68,7 +68,7 @@ const openKnowledgeItems = ref([]);
           <template #title v-if="props.showEdit">
              <div class="d-flex flex-column flex-md-row align-self-center justify-content-end">
                <div class="p-0 m-0 d-inline-flex">
-                 <Button v-if="power.requiredPower" class="mr-2" severity="danger" label="Delete" @click="popups.deleteConfirmation($event, power.id)" />
+                 <Button v-if="!power.requiredPower" class="mr-2" severity="danger" label="Delete" @click="popups.deleteConfirmation($event, power.id)" />
                  <Button class="float-end" label="Edit" @click="dialogs.showEditPower(power)" />
                </div>
              </div>

--- a/client/src/components/characters/character/powers/types.ts
+++ b/client/src/components/characters/character/powers/types.ts
@@ -74,4 +74,5 @@ export interface Power {
     cost: string;
     prerequisites: PrerequisiteDisplay | null;
     userNotes: string | null;
+    requiredPower: boolean;
 }


### PR DESCRIPTION
Delete will now prevent the deletion of a prerequisite power in use
Fixed fluent validation error handling
Updated UI to block the delete button if prerequisite power is in use

Closes #565 