### PR TITLE
Implement Sort Order on CMS Menu

### DIFF
--- a/api/ExpressedRealms.DB/Migrations/20250830015136_AddOrderToCMSTabs.Designer.cs
+++ b/api/ExpressedRealms.DB/Migrations/20250830015136_AddOrderToCMSTabs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ExpressedRealms.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ExpressedRealms.DB.Migrations
 {
     [DbContext(typeof(ExpressedRealmsDbContext))]
-    partial class ExpressedRealmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250830015136_AddOrderToCMSTabs")]
+    partial class AddOrderToCMSTabs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/ExpressedRealms.DB/Migrations/20250830015136_AddOrderToCMSTabs.cs
+++ b/api/ExpressedRealms.DB/Migrations/20250830015136_AddOrderToCMSTabs.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpressedRealms.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderToCMSTabs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "order_index",
+                table: "expression",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+            
+            migrationBuilder.Sql(@"
+                WITH RankedItems AS (
+                    SELECT 
+                        id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY expression_type_id -- Group by ParentId or NULL (root)
+                            ORDER BY id ASC       -- Sort by Id in ascending order
+                        ) AS RowIndex
+                    FROM public.expression
+                )
+                UPDATE public.Expression
+                SET order_index = RankedItems.RowIndex
+                FROM RankedItems
+                WHERE public.expression.id = RankedItems.id;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "order_index",
+                table: "expression");
+        }
+    }
+}

--- a/api/ExpressedRealms.DB/Models/Expressions/ExpressionSetup/Expression.cs
+++ b/api/ExpressedRealms.DB/Models/Expressions/ExpressionSetup/Expression.cs
@@ -15,6 +15,7 @@ public class Expression : ISoftDelete
     public string NavMenuImage { get; set; } = null!;
     public int PublishStatusId { get; set; }
     public int ExpressionTypeId { get; set; }
+    public int OrderIndex { get; set; }
     public bool IsDeleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
 

--- a/api/ExpressedRealms.DB/Models/Expressions/ExpressionSetup/ExpressionAuditConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Expressions/ExpressionSetup/ExpressionAuditConfiguration.cs
@@ -32,6 +32,10 @@ internal static class ExpressionAuditConfiguration
                 case "publish_status_id":
                     changedRecord.FriendlyName = "Publish Status";
                     break;
+                
+                case "order_index":
+                    changedRecord.FriendlyName = "Sort Order";
+                    break;
 
                 default:
                     throw new MissingAuditColumnException(changedRecord.ColumnName);

--- a/api/ExpressedRealms.DB/Models/Expressions/ExpressionSetup/ExpressionAuditConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Expressions/ExpressionSetup/ExpressionAuditConfiguration.cs
@@ -32,7 +32,7 @@ internal static class ExpressionAuditConfiguration
                 case "publish_status_id":
                     changedRecord.FriendlyName = "Publish Status";
                     break;
-                
+
                 case "order_index":
                     changedRecord.FriendlyName = "Sort Order";
                     break;

--- a/api/ExpressedRealms.DB/Models/Expressions/ExpressionSetup/ExpressionConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Expressions/ExpressionSetup/ExpressionConfiguration.cs
@@ -31,6 +31,11 @@ public class ExpressionConfiguration : IEntityTypeConfiguration<Expression>
             .HasColumnName("expression_type_id")
             .IsRequired()
             .HasDefaultValue(1);
+        builder
+            .Property(e => e.OrderIndex)
+            .HasColumnName("order_index")
+            .IsRequired()
+            .HasDefaultValue(1);
         builder.Property(e => e.IsDeleted).HasColumnName("is_deleted");
         builder.Property(e => e.DeletedAt).HasColumnName("deleted_at");
 

--- a/api/ExpressedRealms.Expressions.API/ExpressionEndpoints/EditExpression/EditExpressionEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/ExpressionEndpoints/EditExpression/EditExpressionEndpoint.cs
@@ -22,6 +22,7 @@ internal static class EditExpressionEndpoint
                 PublishStatus = editExpressionRequest.PublishStatus,
                 ShortDescription = editExpressionRequest.ShortDescription,
                 NavMenuImage = editExpressionRequest.NavMenuImage,
+                SortOrder = editExpressionRequest.SortOrder,
             }
         );
 

--- a/api/ExpressedRealms.Expressions.API/ExpressionEndpoints/EditExpression/EditExpressionRequest.cs
+++ b/api/ExpressedRealms.Expressions.API/ExpressionEndpoints/EditExpression/EditExpressionRequest.cs
@@ -9,4 +9,5 @@ public class EditExpressionRequest
     public string ShortDescription { get; set; } = null!;
     public string NavMenuImage { get; set; } = null!;
     public PublishTypes PublishStatus { get; set; }
+    public int SortOrder { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.API/ExpressionEndpoints/GetEditExpression/EditExpressionResponse.cs
+++ b/api/ExpressedRealms.Expressions.API/ExpressionEndpoints/GetEditExpression/EditExpressionResponse.cs
@@ -12,4 +12,5 @@ public class EditExpressionResponse(GetExpressionDto dto)
     public PublishTypes PublishStatus { get; set; } = dto.PublishStatus;
     public List<PublishTypeDto> PublishTypes { get; set; } =
         dto.PublishTypes.Select(x => new PublishTypeDto(x.Key, x.Value)).ToList();
+    public int SortOrder { get; set; } = dto.OrderIndex;
 }

--- a/api/ExpressedRealms.Expressions.Repository/Expressions/DTOs/EditExpressionDto.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Expressions/DTOs/EditExpressionDto.cs
@@ -7,4 +7,5 @@ public record EditExpressionDto
     public string ShortDescription { get; set; } = null!;
     public string NavMenuImage { get; set; } = null!;
     public PublishTypes PublishStatus { get; set; }
+    public int SortOrder { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.Repository/Expressions/DTOs/ExpressionNavigationMenuItem.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Expressions/DTOs/ExpressionNavigationMenuItem.cs
@@ -9,4 +9,5 @@ public class ExpressionNavigationMenuItem
     public string PublishStatusName { get; set; } = null!;
     public PublishTypes PublishStatusId { get; set; }
     public int ExpressionTypeId { get; set; }
+    public int OrderIndex { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.Repository/Expressions/DTOs/GetExpressionDto.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Expressions/DTOs/GetExpressionDto.cs
@@ -8,4 +8,5 @@ public class GetExpressionDto
     public string NavMenuImage { get; set; } = null!;
     public PublishTypes PublishStatus { get; set; }
     public List<KeyValuePair<int, string>> PublishTypes { get; set; } = null!;
+    public int OrderIndex { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.Repository/Expressions/ExpressionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Expressions/ExpressionRepository.cs
@@ -42,7 +42,7 @@ internal sealed class ExpressionRepository(
                 NavMenuImage = x.NavMenuImage,
                 PublishStatusName = x.PublishStatus.Name,
                 PublishStatusId = (PublishTypes)x.PublishStatusId,
-                OrderIndex = x.OrderIndex
+                OrderIndex = x.OrderIndex,
             })
             .OrderBy(x => x.OrderIndex)
             .ToListAsync(cancellationToken);
@@ -75,9 +75,10 @@ internal sealed class ExpressionRepository(
         if (!result.IsValid)
             return Result.Fail(new FluentValidationFailure(result.ToDictionary()));
 
-        var maxSort = await context.Expressions.Where(x => x.ExpressionTypeId == dto.ExpressionTypeId)
+        var maxSort = await context
+            .Expressions.Where(x => x.ExpressionTypeId == dto.ExpressionTypeId)
             .MaxAsync(x => x.OrderIndex, cancellationToken);
-        
+
         var expression = new Expression()
         {
             Name = dto.Name,
@@ -110,7 +111,7 @@ internal sealed class ExpressionRepository(
         expression.ShortDescription = dto.ShortDescription;
         expression.NavMenuImage = dto.NavMenuImage;
         expression.PublishStatusId = (int)dto.PublishStatus;
-        
+
         var sections = await context
             .Expressions.Where(x => x.ExpressionTypeId == expression.ExpressionTypeId)
             .OrderBy(x => x.OrderIndex)
@@ -121,7 +122,7 @@ internal sealed class ExpressionRepository(
         {
             dto.SortOrder = sections.Count;
         }
-        
+
         var index = 1;
         foreach (var item in sections)
         {

--- a/api/ExpressedRealms.Expressions.Repository/Expressions/ExpressionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Expressions/ExpressionRepository.cs
@@ -42,8 +42,9 @@ internal sealed class ExpressionRepository(
                 NavMenuImage = x.NavMenuImage,
                 PublishStatusName = x.PublishStatus.Name,
                 PublishStatusId = (PublishTypes)x.PublishStatusId,
+                OrderIndex = x.OrderIndex
             })
-            .OrderBy(x => x.Name)
+            .OrderBy(x => x.OrderIndex)
             .ToListAsync(cancellationToken);
     }
 
@@ -64,6 +65,7 @@ internal sealed class ExpressionRepository(
             NavMenuImage = expression.NavMenuImage,
             PublishStatus = (PublishTypes)expression.PublishStatusId,
             PublishTypes = EnumHelpers.GetEnumKeyValuePairs<PublishTypes>(),
+            OrderIndex = expression.OrderIndex,
         };
     }
 
@@ -73,6 +75,9 @@ internal sealed class ExpressionRepository(
         if (!result.IsValid)
             return Result.Fail(new FluentValidationFailure(result.ToDictionary()));
 
+        var maxSort = await context.Expressions.Where(x => x.ExpressionTypeId == dto.ExpressionTypeId)
+            .MaxAsync(x => x.OrderIndex, cancellationToken);
+        
         var expression = new Expression()
         {
             Name = dto.Name,
@@ -80,6 +85,7 @@ internal sealed class ExpressionRepository(
             NavMenuImage = dto.NavMenuImage,
             PublishStatusId = (int)PublishTypes.Draft,
             ExpressionTypeId = dto.ExpressionTypeId,
+            OrderIndex = maxSort + 1,
         };
 
         context.Expressions.Add(expression);
@@ -104,6 +110,31 @@ internal sealed class ExpressionRepository(
         expression.ShortDescription = dto.ShortDescription;
         expression.NavMenuImage = dto.NavMenuImage;
         expression.PublishStatusId = (int)dto.PublishStatus;
+        
+        var sections = await context
+            .Expressions.Where(x => x.ExpressionTypeId == expression.ExpressionTypeId)
+            .OrderBy(x => x.OrderIndex)
+            .ToListAsync();
+
+        // Make sure they can't go crazy high
+        if (dto.SortOrder > sections.Count)
+        {
+            dto.SortOrder = sections.Count;
+        }
+        
+        var index = 1;
+        foreach (var item in sections)
+        {
+            // Leave hole in order for new position
+            if (item.OrderIndex == dto.SortOrder)
+            {
+                index++;
+            }
+
+            item.OrderIndex = item.Id == dto.Id ? dto.SortOrder : index;
+
+            index++;
+        }
 
         context.Expressions.Update(expression);
 

--- a/api/ExpressedRealms.Server/EndPoints/NavigationEndpoints/DTOs/ExpressionMenuItem.cs
+++ b/api/ExpressedRealms.Server/EndPoints/NavigationEndpoints/DTOs/ExpressionMenuItem.cs
@@ -18,8 +18,10 @@ public class ExpressionMenuItem
         var helper = new SlugHelper();
         Slug = helper.GenerateSlug(expressionNavigationMenuItem.Name);
         ExpressionTypeId = expressionNavigationMenuItem.ExpressionTypeId;
+        OrderIndex = expressionNavigationMenuItem.OrderIndex;
     }
 
+    public int OrderIndex { get; set; }
     public int ExpressionTypeId { get; set; }
     public int Id { get; init; }
     public string Name { get; init; }

--- a/api/ExpressedRealms.Server/EndPoints/NavigationEndpoints/NavigationEndpoints.cs
+++ b/api/ExpressedRealms.Server/EndPoints/NavigationEndpoints/NavigationEndpoints.cs
@@ -125,18 +125,14 @@ internal static class NavigationEndpoints
                             ]
                         );
                     }
-                    
+
                     var sorted = menuItems
                         .OrderBy(x => x.ExpressionTypeId)
                         .ThenBy(x => x.OrderIndex)
                         .ToList();
 
                     return TypedResults.Ok(
-                        new ExpressionMenuResponse()
-                        {
-                            CanEdit = hasEditPolicy,
-                            MenuItems = sorted,
-                        }
+                        new ExpressionMenuResponse() { CanEdit = hasEditPolicy, MenuItems = sorted }
                     );
                 }
             )

--- a/api/ExpressedRealms.Server/EndPoints/NavigationEndpoints/NavigationEndpoints.cs
+++ b/api/ExpressedRealms.Server/EndPoints/NavigationEndpoints/NavigationEndpoints.cs
@@ -101,6 +101,7 @@ internal static class NavigationEndpoints
                                     ShortDescription = $"Use this to add a new Expression",
                                     ExpressionTypeId = 1,
                                     NavMenuImage = "add",
+                                    OrderIndex = 1000000000,
                                 },
                                 new ExpressionMenuItem()
                                 {
@@ -109,6 +110,7 @@ internal static class NavigationEndpoints
                                     ShortDescription = $"Use this to add a new Rule Book Section",
                                     NavMenuImage = "add",
                                     ExpressionTypeId = 13,
+                                    OrderIndex = 1000000000,
                                 },
                                 new ExpressionMenuItem()
                                 {
@@ -118,16 +120,22 @@ internal static class NavigationEndpoints
                                         $"Use this to add a new World Background Section",
                                     NavMenuImage = "add",
                                     ExpressionTypeId = 14,
+                                    OrderIndex = 1000000000,
                                 },
                             ]
                         );
                     }
+                    
+                    var sorted = menuItems
+                        .OrderBy(x => x.ExpressionTypeId)
+                        .ThenBy(x => x.OrderIndex)
+                        .ToList();
 
                     return TypedResults.Ok(
                         new ExpressionMenuResponse()
                         {
                             CanEdit = hasEditPolicy,
-                            MenuItems = menuItems,
+                            MenuItems = sorted,
                         }
                     );
                 }

--- a/client/src/components/expressions/EditExpression.vue
+++ b/client/src/components/expressions/EditExpression.vue
@@ -26,6 +26,7 @@ onMounted(() =>{
         navMenuImage.value = response.data.navMenuImage;
         publishStatus.value = response.data.publishTypes.find(x => x.id == response.data.publishStatus);
         publishStatusOptions.value = response.data.publishTypes;
+        sortOrder.value = response.data.sortOrder;
         isLoading.value = false;
       })
 });
@@ -42,7 +43,9 @@ const { defineField, handleSubmit, errors } = useForm({
     navMenuImage: string().required()
         .label('Nav Menu Icon'),
     publishStatus: object().required()
-        .label('Publish Status')
+        .label('Publish Status'),
+    sortOrder: number().required()
+        .label('Sort Order')
   })
 });
 
@@ -50,6 +53,7 @@ const [name] = defineField('name');
 const [shortDescription] = defineField('shortDescription');
 const [navMenuImage] = defineField('navMenuImage');
 const [publishStatus] = defineField('publishStatus');
+const [sortOrder] = defineField('sortOrder');
 
 const onSubmit = handleSubmit((values) => {
   axios.put(`/expression/${expressionId.value}`, {
@@ -57,7 +61,8 @@ const onSubmit = handleSubmit((values) => {
     shortDescription: values.shortDescription,
     id: expressionId.value,
     publishStatus: values.publishStatus.id,
-    navMenuImage: values.navMenuImage
+    navMenuImage: values.navMenuImage,
+    sortOrder: Number(values.sortOrder),
   }).then(() => {
     cmsData.refreshCmsInformation();
     toaster.success("Successfully Updated Expression Info!");
@@ -87,6 +92,8 @@ const onSubmit = handleSubmit((values) => {
       v-model="publishStatus" option-label="name" :options="publishStatusOptions" field-name="Publish Status" :error-text="errors.publishStatus"
       :show-skeleton="isLoading"
     />
+    <InputTextWrapper v-model="sortOrder" field-name="Sort Order" :error-text="errors.sortOrder" :show-skeleton="isLoading"/>
+    <p>Keep in mind, for 6 items, sort order is first column starts at one, and ends at 3, and 2nd column starts at 4 and ends at 6</p>
     <Button label="Save" class="w-100 mb-2" type="submit" />
   </form>
 </template>

--- a/client/src/components/navbar/navMenuItems/types.ts
+++ b/client/src/components/navbar/navMenuItems/types.ts
@@ -7,6 +7,7 @@ export interface ExpressionMenuItem {
     statusId: number;
     slug: string;
     expressionTypeId: number;
+    orderIndex: number;
 }
 
 export interface ExpressionMenuResponse{


### PR DESCRIPTION
It shouldn't be sorted by name, instead it should be sorted by sort index.
Expressions are also getting this functionality as well
Any new sections will be added to the list, you can modify the position on edit