### PR TITLE
Add Blessing UI - Part 1

### DIFF
--- a/api/ExpressedRealms.Blessings.API/Blessings/GetAllBlessings/Blessing.cs
+++ b/api/ExpressedRealms.Blessings.API/Blessings/GetAllBlessings/Blessing.cs
@@ -7,4 +7,5 @@ public class Blessing
     public required string Description { get; set; }
     public string? SubCategory { get; set; }
     public List<Level> Levels { get; set; } = new();
+    public required string Type { get; set; }
 }

--- a/api/ExpressedRealms.Blessings.API/Blessings/GetAllBlessings/GetAllBlessingsEndpoint.cs
+++ b/api/ExpressedRealms.Blessings.API/Blessings/GetAllBlessings/GetAllBlessingsEndpoint.cs
@@ -36,6 +36,7 @@ public static class GetAllBlessingsEndpoint
                 Id = x.Id,
                 Name = x.Name,
                 Description = x.Description,
+                Type = x.Type,
                 SubCategory = x.SubCategory,
                 Levels = x
                     .Levels.OrderBy(y => y.Level)

--- a/api/ExpressedRealms.Blessings.Repository/Blessings/BlessingRepository.cs
+++ b/api/ExpressedRealms.Blessings.Repository/Blessings/BlessingRepository.cs
@@ -18,9 +18,20 @@ internal sealed class BlessingRepository(
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<bool> HasDuplicateName(string name)
+    public async Task<bool> HasDuplicateName(string name, int blessingId = 0)
     {
-        return await context.Blessings.AnyAsync(x => x.Name == name, cancellationToken);
+        if (blessingId != 0)
+        {
+            return await context
+                .Blessings.AsNoTracking()
+                .AnyAsync(
+                    x => x.Name.ToLower() == name.ToLower() && x.Id != blessingId,
+                    cancellationToken
+                );
+        }
+        return await context
+            .Blessings.AsNoTracking()
+            .AnyAsync(x => x.Name.ToLower() == name.ToLower(), cancellationToken);
     }
 
     public async Task<bool> HasDuplicateLevelName(int blessingId, string name)

--- a/api/ExpressedRealms.Blessings.Repository/Blessings/IBlessingRepository.cs
+++ b/api/ExpressedRealms.Blessings.Repository/Blessings/IBlessingRepository.cs
@@ -6,7 +6,7 @@ namespace ExpressedRealms.Blessings.Repository.Blessings;
 public interface IBlessingRepository
 {
     Task<List<Blessing>> GetAllBlessingsAndBlessingLevels();
-    Task<bool> HasDuplicateName(string name);
+    Task<bool> HasDuplicateName(string name, int blessingId = 0);
     Task<int> CreateBlessingAsync(Blessing blessing);
     Task<Blessing> GetBlessingForEditing(int id);
     Task EditBlessingAsync(Blessing blessing);

--- a/api/ExpressedRealms.Blessings.UseCases.Tests.Unit/CreateBlessingUseCaseTests.cs
+++ b/api/ExpressedRealms.Blessings.UseCases.Tests.Unit/CreateBlessingUseCaseTests.cs
@@ -25,7 +25,7 @@ public class CreateBlessingUseCaseTests
 
         _repository = A.Fake<IBlessingRepository>();
 
-        A.CallTo(() => _repository.HasDuplicateName(_model.Name)).Returns(false);
+        A.CallTo(() => _repository.HasDuplicateName(_model.Name, 0)).Returns(false);
 
         var validator = new CreateBlessingModelValidator(_repository);
 
@@ -56,7 +56,7 @@ public class CreateBlessingUseCaseTests
     [Fact]
     public async Task ValidationFor_Name_WillFail_WhenName_AlreadyExists()
     {
-        A.CallTo(() => _repository.HasDuplicateName(_model.Name)).Returns(true);
+        A.CallTo(() => _repository.HasDuplicateName(_model.Name, 0)).Returns(true);
 
         var results = await _useCase.ExecuteAsync(_model);
         results.MustHaveValidationError(

--- a/api/ExpressedRealms.Blessings.UseCases.Tests.Unit/EditBlessingUseCaseTests.cs
+++ b/api/ExpressedRealms.Blessings.UseCases.Tests.Unit/EditBlessingUseCaseTests.cs
@@ -37,7 +37,7 @@ public class EditBlessingUseCaseTests
 
         A.CallTo(() => _repository.GetBlessingForEditing(_model.Id)).Returns(_dbModel);
         A.CallTo(() => _repository.IsExistingBlessing(_model.Id)).Returns(true);
-        A.CallTo(() => _repository.HasDuplicateName(_model.Name)).Returns(false);
+        A.CallTo(() => _repository.HasDuplicateName(_model.Name, _model.Id)).Returns(false);
 
         var validator = new EditBlessingModelValidator(_repository);
 
@@ -85,7 +85,7 @@ public class EditBlessingUseCaseTests
     [Fact]
     public async Task ValidationFor_Name_WillFail_WhenName_AlreadyExists()
     {
-        A.CallTo(() => _repository.HasDuplicateName(_model.Name)).Returns(true);
+        A.CallTo(() => _repository.HasDuplicateName(_model.Name, _model.Id)).Returns(true);
 
         var results = await _useCase.ExecuteAsync(_model);
         results.MustHaveValidationError(

--- a/api/ExpressedRealms.Blessings.UseCases/Blessings/EditBlessings/EditBlessingModelValidator.cs
+++ b/api/ExpressedRealms.Blessings.UseCases/Blessings/EditBlessings/EditBlessingModelValidator.cs
@@ -19,8 +19,11 @@ internal sealed class EditBlessingModelValidator : AbstractValidator<EditBlessin
             .NotEmpty()
             .WithMessage("Name is required.")
             .MaximumLength(250)
-            .WithMessage("Name must be between 1 and 250 characters.")
-            .MustAsync(async (x, y) => !await repository.HasDuplicateName(x))
+            .WithMessage("Name must be between 1 and 250 characters.");
+        
+        RuleFor(x => x)
+            .MustAsync(async (x, y) => !await repository.HasDuplicateName(x.Name, x.Id))
+            .WithName(nameof(EditBlessingModel.Name))
             .WithMessage("Blessing with this name already exists.");
 
         RuleFor(x => x.Description).NotEmpty().WithMessage("Description is required.");

--- a/api/ExpressedRealms.Blessings.UseCases/Blessings/EditBlessings/EditBlessingModelValidator.cs
+++ b/api/ExpressedRealms.Blessings.UseCases/Blessings/EditBlessings/EditBlessingModelValidator.cs
@@ -20,7 +20,7 @@ internal sealed class EditBlessingModelValidator : AbstractValidator<EditBlessin
             .WithMessage("Name is required.")
             .MaximumLength(250)
             .WithMessage("Name must be between 1 and 250 characters.");
-        
+
         RuleFor(x => x)
             .MustAsync(async (x, y) => !await repository.HasDuplicateName(x.Name, x.Id))
             .WithName(nameof(EditBlessingModel.Name))

--- a/api/ExpressedRealms.Shared.FeatureFlags/ReleaseFlags.cs
+++ b/api/ExpressedRealms.Shared.FeatureFlags/ReleaseFlags.cs
@@ -41,13 +41,13 @@ public sealed class ReleaseFlags : SmartEnum<ReleaseFlags, string>
         "show-faction-dropdown",
         "Allows one to see the faction dropdown on the add / edit character page"
     );
-    
+
     public static readonly ReleaseFlags ShowBlessingCMS = new(
         "Shows the purpose built blessing CMS system",
         "show-blessing-cms",
         "Allows one to see blessing CMS system"
     );
-    
+
     public static readonly ReleaseFlags HideBlessingSections = new(
         "Hides the sections that exist in the blessing CMS system",
         "hide-blessing-sections",

--- a/api/ExpressedRealms.Shared.FeatureFlags/ReleaseFlags.cs
+++ b/api/ExpressedRealms.Shared.FeatureFlags/ReleaseFlags.cs
@@ -41,6 +41,18 @@ public sealed class ReleaseFlags : SmartEnum<ReleaseFlags, string>
         "show-faction-dropdown",
         "Allows one to see the faction dropdown on the add / edit character page"
     );
+    
+    public static readonly ReleaseFlags ShowBlessingCMS = new(
+        "Shows the purpose built blessing CMS system",
+        "show-blessing-cms",
+        "Allows one to see blessing CMS system"
+    );
+    
+    public static readonly ReleaseFlags HideBlessingSections = new(
+        "Hides the sections that exist in the blessing CMS system",
+        "hide-blessing-sections",
+        "Hides the sections that exist in the blessing CMS system"
+    );
 
     public override string ToString()
     {

--- a/client/src/components/blessings/AddBlessing.vue
+++ b/client/src/components/blessings/AddBlessing.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+
+import FormInputTextWrapper from "@/FormWrappers/FormInputTextWrapper.vue";
+import Button from "primevue/button";
+import FormTextAreaWrapper from "@/FormWrappers/FormTextAreaWrapper.vue";
+import {getValidationInstance} from "@/components/blessings/validations/blessingForm.ts";
+import {blessingsStore} from "@/components/blessings/stores/blessingsStore.ts";
+
+const store = blessingsStore();
+
+const form = getValidationInstance()
+const emit = defineEmits<{
+  canceled: []
+}>();
+
+
+const onSubmit = form.handleSubmit(async (values) => {
+  await store.addBlessing(values);
+  cancel();
+});
+
+const cancel = () => {
+  emit("canceled");
+}
+
+</script>
+
+<template>
+  <form @submit="onSubmit">
+
+    <FormInputTextWrapper v-model="form.type" />
+    
+    <FormInputTextWrapper v-model="form.subCategory" />
+    
+    <FormInputTextWrapper v-model="form.name" />
+
+    <FormTextAreaWrapper v-model="form.description" />
+
+    <div class="m-3 text-right">
+      <Button label="Cancel" class="m-2" type="reset" @click="cancel" />
+      <Button label="Add" class="m-2" type="submit" />
+    </div>
+  </form>
+</template>

--- a/client/src/components/blessings/BlessingItem.vue
+++ b/client/src/components/blessings/BlessingItem.vue
@@ -5,7 +5,9 @@ import type {Blessing} from "@/components/blessings/types";
 import EditBlessing from "@/components/blessings/EditBlessing.vue";
 import {UserRoles, userStore} from "@/stores/userStore.ts";
 import Button from "primevue/button";
+import {blessingConfirmationPopup} from "@/components/blessings/services/blessingConfirmationPopupService.ts";
 
+const popups = blessingConfirmationPopup();
 const userInfo = userStore();
 const props = defineProps({
   blessing: {
@@ -42,7 +44,7 @@ function toggleEdit(){
         v-if="!showEdit && userInfo.hasUserRole(UserRoles.BlessingsManagementRole) && !props.isReadOnly"
         class="p-0 m-0 d-inline-flex align-items-start"
     >
-<!--      <Button class="mr-2" severity="danger" label="Delete" @click="popups.deleteConfirmation($event)" />-->
+      <Button class="mr-2" severity="danger" label="Delete" @click="popups.deleteConfirmation($event, props.blessing.id)" />
       <Button class="float-end" label="Edit" @click="toggleEdit" />
     </div>
   </div>

--- a/client/src/components/blessings/BlessingItem.vue
+++ b/client/src/components/blessings/BlessingItem.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
 
-import {type PropType} from "vue";
+import {type PropType, ref} from "vue";
 import type {Blessing} from "@/components/blessings/types";
+import EditBlessing from "@/components/blessings/EditBlessing.vue";
+import {UserRoles, userStore} from "@/stores/userStore.ts";
+import Button from "primevue/button";
 
+const userInfo = userStore();
 const props = defineProps({
   blessing: {
     type: Object as PropType<Blessing>,
@@ -13,9 +17,18 @@ const props = defineProps({
     required: true
   }
 });
+
+const showEdit = ref(false);
+
+function toggleEdit(){
+  showEdit.value = !showEdit.value;
+}
 </script>
 
 <template>
+  <div v-if="showEdit" class="mb-2">
+    <EditBlessing :blessing="props.blessing" @canceled="toggleEdit" />
+  </div>
   <div class="d-flex flex-column flex-md-row align-self-center justify-content-between mt-4">
     <div>
       <h1 class="p-0 m-0">
@@ -24,6 +37,13 @@ const props = defineProps({
       <div class="p-0 m-0">
         {{ props.blessing?.subCategory }}
       </div>
+    </div>
+    <div
+        v-if="!showEdit && userInfo.hasUserRole(UserRoles.BlessingsManagementRole) && !props.isReadOnly"
+        class="p-0 m-0 d-inline-flex align-items-start"
+    >
+<!--      <Button class="mr-2" severity="danger" label="Delete" @click="popups.deleteConfirmation($event)" />-->
+      <Button class="float-end" label="Edit" @click="toggleEdit" />
     </div>
   </div>
   <p>{{ props.blessing.description }}</p>

--- a/client/src/components/blessings/BlessingList.vue
+++ b/client/src/components/blessings/BlessingList.vue
@@ -71,9 +71,11 @@ const sortedDisadvantages = computed(() => {
 
 <template>
   <div v-if="showEdit" class="text-right">
-    <Button label="Add Advantage" @click="toggleAdd" />
-    <AddBlessing v-if="showAdd" @canceled="toggleAdd" />
+    <Button v-if="!showAdd" label="Add Advantage" @click="toggleAdd" />
+    <Button v-else label="Cancel Add" @click="toggleAdd" />
+    
   </div>
+  <AddBlessing v-if="showAdd" @canceled="toggleAdd" />
   <div>
     <h1>Advantage</h1>
     <div v-for="blessing in sortedAdvantages" :key="blessing.id">

--- a/client/src/components/blessings/BlessingList.vue
+++ b/client/src/components/blessings/BlessingList.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 
-import {computed, onMounted} from "vue";
+import {computed, onMounted, ref} from "vue";
 import {blessingsStore} from "@/components/blessings/stores/blessingsStore";
 import BlessingItem from "@/components/blessings/BlessingItem.vue";
+import {UserRoles, userStore} from "@/stores/userStore.ts";
+import AddBlessing from "@/components/blessings/AddBlessing.vue";
+import Button from "primevue/button";
 
 const store = blessingsStore();
+const userInfo = userStore();
 
-onMounted(async () => {
-  await store.getBlessings()
-})
 
 const props = defineProps({
   isReadOnly: {
@@ -16,6 +17,18 @@ const props = defineProps({
     required: true
   }
 });
+
+const showEdit = ref(false);
+const showAdd = ref(false);
+
+const toggleAdd = () =>{
+  showAdd.value = !showAdd.value;
+}
+
+onMounted(async () => {
+  await store.getBlessings()
+  showEdit.value = userInfo.hasUserRole(UserRoles.BlessingsManagementRole);
+})
 
 const sortedAdvantages = computed(() => {
   return [...store.advantages].sort((a, b) => {
@@ -57,6 +70,10 @@ const sortedDisadvantages = computed(() => {
 </script>
 
 <template>
+  <div v-if="showEdit" class="text-right">
+    <Button label="Add Advantage" @click="toggleAdd" />
+    <AddBlessing v-if="showAdd" @canceled="toggleAdd" />
+  </div>
   <div>
     <h1>Advantage</h1>
     <div v-for="blessing in sortedAdvantages" :key="blessing.id">

--- a/client/src/components/blessings/EditBlessing.vue
+++ b/client/src/components/blessings/EditBlessing.vue
@@ -4,6 +4,8 @@ import FormInputTextWrapper from "@/FormWrappers/FormInputTextWrapper.vue";
 import Button from "primevue/button";
 import {getValidationInstance} from "@/components/blessings/validations/blessingForm.ts";
 import {blessingsStore} from "@/components/blessings/stores/blessingsStore.ts";
+import {onBeforeMount, type PropType} from "vue";
+import type {Blessing} from "@/components/blessings/types.ts";
 import FormEditorWrapper from "@/FormWrappers/FormEditorWrapper.vue";
 
 const store = blessingsStore();
@@ -13,9 +15,20 @@ const emit = defineEmits<{
   canceled: []
 }>();
 
+const props = defineProps({
+  blessing: {
+    type: Object as PropType<Blessing>,
+    required: true,
+  }
+});
+
+onBeforeMount(async () => {
+  form.setValues(props.blessing);
+})
+
 
 const onSubmit = form.handleSubmit(async (values) => {
-  await store.addBlessing(values);
+  await store.editBlessing(props.blessing.id, values);
   cancel();
 });
 
@@ -38,7 +51,7 @@ const cancel = () => {
 
     <div class="m-3 text-right">
       <Button label="Cancel" class="m-2" type="reset" @click="cancel" />
-      <Button label="Add" class="m-2" type="submit" />
+      <Button label="Update" class="m-2" type="submit" />
     </div>
   </form>
 </template>

--- a/client/src/components/blessings/services/blessingConfirmationPopupService.ts
+++ b/client/src/components/blessings/services/blessingConfirmationPopupService.ts
@@ -1,0 +1,33 @@
+import {useConfirm} from "primevue/useconfirm";
+import {knowledgeStore} from "@/components/knowledges/stores/knowledgeStore";
+import {blessingsStore} from "@/components/blessings/stores/blessingsStore.ts";
+
+export const blessingConfirmationPopup = () => {
+
+    const confirm = useConfirm();
+    const store = blessingsStore();
+
+    const deleteConfirmation = (event: MouseEvent, blessingId: number) =>
+        confirm.require({
+        target: event.target as HTMLElement,
+        group: 'popup',
+        message: `Do you want to delete this blessing?`,
+        icon: 'pi pi-info-circle',
+        rejectProps: {
+            label: 'Cancel',
+            severity: 'secondary',
+            outlined: true
+        },
+        acceptProps: {
+            label: 'Delete Blessing',
+            severity: 'danger'
+        },
+        accept: () => {
+            store.deleteBlessing(blessingId);
+        }
+    });
+
+    return { deleteConfirmation };
+
+};
+

--- a/client/src/components/blessings/services/blessingConfirmationPopupService.ts
+++ b/client/src/components/blessings/services/blessingConfirmationPopupService.ts
@@ -1,5 +1,4 @@
 import {useConfirm} from "primevue/useconfirm";
-import {knowledgeStore} from "@/components/knowledges/stores/knowledgeStore";
 import {blessingsStore} from "@/components/blessings/stores/blessingsStore.ts";
 
 export const blessingConfirmationPopup = () => {

--- a/client/src/components/blessings/stores/blessingsStore.ts
+++ b/client/src/components/blessings/stores/blessingsStore.ts
@@ -1,6 +1,8 @@
 import {defineStore} from "pinia";
 import axios from "axios";
 import type {Blessing, BlessingRequest} from "@/components/blessings/types";
+import type {BlessingForm} from "@/components/blessings/validations/blessingForm.ts";
+import toaster from "@/services/Toasters";
 
 export const blessingsStore =
     defineStore(`blessings`, {
@@ -17,6 +19,31 @@ export const blessingsStore =
                 this.advantages = response.data.advantages
                 this.disadvantages = response.data.disadvantages
                 this.mixedBlessings = response.data.mixedBlessings
+            },
+            async addBlessing(blessing: BlessingForm){
+                await axios.post(`/blessings/`, {
+                    name: blessing.name,
+                    description: blessing.description,
+                    category: blessing.subCategory,
+                    type: blessing.type
+                });
+                toaster.success("Successfully added Blessing!");
+                await this.getBlessings();
+            },
+            async editBlessing(blessingId: number, blessing: BlessingForm){
+                await axios.put(`/blessings/${blessingId}`, {
+                    name: blessing.name,
+                    description: blessing.description,
+                    category: blessing.subCategory,
+                    type: blessing.type
+                });
+                toaster.success("Successfully edited Blessing!");
+                await this.getBlessings();
+            },
+            async deleteBlessing(blessingId: number){
+                await axios.delete(`/blessings/${blessingId}`);
+                toaster.success("Successfully deleted Blessing!");
+                await this.getBlessings();
             }
         }
     });

--- a/client/src/components/blessings/types.ts
+++ b/client/src/components/blessings/types.ts
@@ -9,6 +9,7 @@ export interface Blessing {
     id: number,
     name: string,
     description: string,
+    type: string,
     subCategory: string | null,
     levels: Array<BlessingLevel>
     typeId: number

--- a/client/src/components/blessings/validations/blessingForm.ts
+++ b/client/src/components/blessings/validations/blessingForm.ts
@@ -1,6 +1,5 @@
 import {type InferType, object, string} from "yup";
 import {useGenericForm} from "@/utilities/formUtilities";
-import type {ListItem} from "@/types/ListItem";
 import type {Blessing} from "@/components/blessings/types.ts";
 
 const validationSchema = object({

--- a/client/src/components/blessings/validations/blessingForm.ts
+++ b/client/src/components/blessings/validations/blessingForm.ts
@@ -1,0 +1,52 @@
+import {type InferType, object, string} from "yup";
+import {useGenericForm} from "@/utilities/formUtilities";
+import type {ListItem} from "@/types/ListItem";
+import type {Blessing} from "@/components/blessings/types.ts";
+
+const validationSchema = object({
+    name: string()
+        .required()
+        .max(250)
+        .label("Name"),
+    description: string()
+        .required()
+        .label("Description"),
+    type: string()
+        .required()
+        .label("Type"),
+    subCategory: string()
+        .required()
+        .label("Sub Category Type"),
+});
+
+export type BlessingForm = InferType<typeof validationSchema>;
+
+export function getValidationInstance() {
+        
+    const form = useGenericForm(validationSchema);
+    
+    const setValues = (power: Blessing) => {
+        form.fields.name.field.value = power.name;
+        form.fields.description.field.value = power.description;
+        form.fields.type.field.value = power.type;
+        form.fields.subCategory.field.value = power.subCategory;
+    }
+    
+    const customResetForm = () => {
+        form.fields.description.field.value = "";
+        form.fields.name.field.value = "";
+        form.fields.type.field.value = "";
+        form.fields.subCategory.field.value = "";
+        form.handleReset();
+    };
+    
+    return {
+        handleSubmit: form.handleSubmit, 
+        customResetForm,
+        setValues,
+        name: form.fields.name,
+        description: form.fields.description,
+        type: form.fields.type,
+        subCategory: form.fields.subCategory,
+    }
+}

--- a/client/src/components/expressions/CmsBase.vue
+++ b/client/src/components/expressions/CmsBase.vue
@@ -54,7 +54,7 @@ async function fetchData() {
   await expressionInfo.getExpressionSections()
       .then(async () => {
         sections.value = expressionInfo.sections;
-        showEdit.value = expressionInfo.canEdit;
+        showEdit.value = userInfo.hasUserRole(UserRoles.ExpressionEditor)
         isLoading.value = false;
         if(location.hash){
           await nextTick();

--- a/client/src/components/expressions/EditExpressionSection.vue
+++ b/client/src/components/expressions/EditExpressionSection.vue
@@ -3,14 +3,14 @@
 import {makeIdSafe} from "@/utilities/stringUtilities";
 import Skeleton from "primevue/skeleton";
 import Button from "primevue/button";
-import {ref} from "vue";
+import {onMounted, ref} from "vue";
 import axios from "axios";
 import {useForm} from "vee-validate";
 import {object, string} from "yup";
 import InputTextWrapper from "@/FormWrappers/InputTextWrapper.vue";
 import DropdownWrapper from "@/FormWrappers/DropdownWrapper.vue";
 
-import { expressionStore } from "@/stores/expressionStore";
+import {expressionStore} from "@/stores/expressionStore";
 import EditorWrapper from "@/FormWrappers/EditorWrapper.vue";
 import toaster from "@/services/Toasters";
 import CreateExpressionSection from "@/components/expressions/CreateExpressionSection.vue";
@@ -18,6 +18,8 @@ import {useConfirm} from "primevue/useconfirm";
 import DataTable from "primevue/datatable";
 import KnowledgeList from "@/components/knowledges/KnowledgeList.vue";
 import BlessingList from "@/components/blessings/BlessingList.vue";
+import {FeatureFlags, userStore} from "@/stores/userStore.ts";
+
 const expressionInfo = expressionStore();
 
 const emit = defineEmits<{
@@ -50,6 +52,12 @@ const showEditor = ref(false);
 const showOptionLoader = ref(true);
 const sectionTypeOptions = ref([]);
 const showCreate = ref(false);
+const showBlessingCms = ref(false);
+const userInfo = userStore();
+
+onMounted(  async() =>  {
+  showBlessingCms.value = await userInfo.hasFeatureFlag(FeatureFlags.ShowBlessingCMS)
+})
 
 function toggleEditor(){
   showEditor.value = !showEditor.value;
@@ -202,7 +210,7 @@ const deleteExpression = (event) => {
     <div v-if="props.sectionInfo.sectionTypeName === 'Knowledges Section'">
       <KnowledgeList :is-read-only="!showEdit" />
     </div>
-    <div v-if="props.sectionInfo.sectionTypeName === 'Blessings Section'">
+    <div v-if="props.sectionInfo.sectionTypeName === 'Blessings Section' && showBlessingCms">
       <BlessingList :is-read-only="!showEdit" />
     </div>
     

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -9,13 +9,16 @@ export const UserRoles = {
     KnowledgeManagementRole: "KnowledgeManagementRole",
     DownloadCMSReports: "DownloadCMSReports",
     DownloadExpressionBooklet: "DownloadExpressionBooklet",
+    BlessingsManagementRole: "ManageBlessingsRole",
 } as const;
 
 export const FeatureFlags = {
     ShowMarketingContactUs: "show-marketing-contact-us",
     ShowInventoryPage: "show-inventory-page",
     ShowCharacterPowers: "show-character-powers",
-    ShowFactionDropdown: "show-faction-dropdown"
+    ShowFactionDropdown: "show-faction-dropdown",
+    ShowBlessingCMS: "show-blessing-cms",
+    HideBlessingSections: "hide-blessing-sections",
 } as const;
 
 export type UserRole = (typeof UserRoles)[keyof typeof UserRoles];

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
 
   postgres:
     container_name: expressed-realms-db
-    image: postgres:14-alpine
+    image: postgres:16-alpine
     ports:
       - 5432:5432
     volumes:
@@ -107,7 +107,7 @@ services:
       retries: 3
 
   pgadmin:
-    image: dpage/pgadmin4:9.6.0
+    image: dpage/pgadmin4:latest
     container_name: expressed-realms-db-admin
     ports:
       - "8888:80"


### PR DESCRIPTION
Buttons on CMS pages will now correctly respect the Expression Editor Role
Added feature flag to hide the DB portion of the Blessing Stuff
Fixed duplicate name check on overall blessing
You can now add / edit / remove the overall blessing - no support for levels yet
Updated Postgres and pgAdmin to latest version in docker file
