### PR TITLE
Updated Event Release Message Again

### DIFF
--- a/api/ExpressedRealms.Events.API.Tests.Unit/Events/SendEventPublishedMessagesUseCaseTests.cs
+++ b/api/ExpressedRealms.Events.API.Tests.Unit/Events/SendEventPublishedMessagesUseCaseTests.cs
@@ -347,7 +347,7 @@ public class SendEventPublishedMessagesUseCaseTests
             )
             .MustHaveHappenedOnceExactly();
     }
-    
+
     [Fact]
     public async Task UseCase_ContainsMessage_DailyScheduleWillBeReleasedLater_ForInitialAnnouncement()
     {
@@ -369,7 +369,9 @@ public class SendEventPublishedMessagesUseCaseTests
     [InlineData(PublishType.OneMonthReminder)]
     [InlineData(PublishType.OneWeekReminder)]
     [InlineData(PublishType.DayOfReminder)]
-    public async Task UseCase_OnlyContainsMessage_DailyScheduleWillBeReleasedLater_OnDayOfReminder(PublishType type)
+    public async Task UseCase_OnlyContainsMessage_DailyScheduleWillBeReleasedLater_OnDayOfReminder(
+        PublishType type
+    )
     {
         _model.PublishType = type;
         await _useCase.ExecuteAsync(_model);

--- a/api/ExpressedRealms.Events.API/UseCases/Events/SendEventPublishedMessages/SendEventPublishedMessagesUseCase.cs
+++ b/api/ExpressedRealms.Events.API/UseCases/Events/SendEventPublishedMessages/SendEventPublishedMessagesUseCase.cs
@@ -71,7 +71,9 @@ internal sealed class SendEventPublishedMessagesUseCase(
 
         if (model.PublishType == PublishType.InitialAnnouncement)
         {
-            message.AppendLine("The daily schedule will be provided roughly a month out from the event.");
+            message.AppendLine(
+                "The daily schedule will be provided roughly a month out from the event."
+            );
         }
 
         if (model.PublishType != PublishType.InitialAnnouncement)


### PR DESCRIPTION
Will now show "The daily schedule will be provided roughly a month out from the event" under the We will be there heading

This was added to highlight the header a bit better