### PR TITLE
Redis Connection String Fixed - Quartz Config Updated

### DIFF
--- a/api/ExpressedRealms.Server/CronJobs/QuartzConfiguration.cs
+++ b/api/ExpressedRealms.Server/CronJobs/QuartzConfiguration.cs
@@ -14,7 +14,12 @@ public static class QuartzConfiguration
                 .AddTrigger(opts =>
                     opts.ForJob(EventCronJob.Key)
                         .WithIdentity("event-trigger", "cron-group")
-                        .WithCronSchedule("0 0 4 1/1 * ? * ")
+                        .WithCronSchedule(
+                            "0 0 4 1/1 * ? *",
+                            x => x.InTimeZone(
+                                TimeZoneInfo.FindSystemTimeZoneById("America/Chicago")
+                            )
+                        )
                 ); // Every day around 4am
         });
         builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);

--- a/api/ExpressedRealms.Server/appsettings.docker.json
+++ b/api/ExpressedRealms.Server/appsettings.docker.json
@@ -5,7 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AZURE_REDIS_CONNECTIONSTRING": "redis:6379",
+  "AZURE-REDIS-CONNECTIONSTRING": "redis:6379",
   "POSTGRES-CONNECTION-STRING": "Host=expressed-realms-db;Port=5432;Database=expressedRealms;Username=dev_user;Password=dev_password",
   "AZURE-STORAGEBLOB-RESOURCEENDPOINT": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;",
   "FRONT-END-BASE-URL": "http://myapp:3001",

--- a/api/ExpressedRealms.Server/appsettings.json
+++ b/api/ExpressedRealms.Server/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "AllowedHosts": "*",
-  "AZURE_REDIS_CONNECTIONSTRING": "localhost:6379",
+  "AZURE-REDIS-CONNECTIONSTRING": "localhost:6379",
   "POSTGRES-CONNECTION-STRING": "Host=localhost;Port=5432;Database=expressedRealms;Username=dev_user;Password=dev_password",
   "AZURE-STORAGEBLOB-RESOURCEENDPOINT": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;",
   "FRONT-END-BASE-URL": "http://localhost:3001",

--- a/api/ExpressedRealms.Shared/AzureKeyVault/Secrets/ConnectionStrings.cs
+++ b/api/ExpressedRealms.Shared/AzureKeyVault/Secrets/ConnectionStrings.cs
@@ -9,8 +9,10 @@ public static class ConnectionStrings
         "APPLICATION-INSIGHTS-CONNECTION-STRING"
     );
     public static readonly KeyVaultSecret BlobStorage = new("AZURE-STORAGEBLOB-RESOURCEENDPOINT");
+    // This is formatted differently due to it being in the github workflow file
+    // do not blindly copy this style, use "-" instead
     public static readonly KeyVaultSecret AzureKeyVault = new("AZURE_KEYVAULT_RESOURCEENDPOINT");
     public static readonly KeyVaultSecret RedisConnectionString = new(
-        "AZURE_REDIS_CONNECTIONSTRING"
+        "AZURE-REDIS-CONNECTIONSTRING"
     );
 }


### PR DESCRIPTION
Quartz needs timezone info in order to send message on time Before it was doing it around 10pm cause 4am utc translated to that Redis was missing "-" in its connection name