### PR TITLE
Fixed Blessings Not Enforcing XP Correctly

### DIFF
--- a/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
@@ -35,7 +35,6 @@ internal sealed class CharacterRepository(
             {
                 Id = x.Id.ToString(),
                 Name = x.Name,
-                Background = x.Background,
                 Expression = x.Expression.Name,
                 IsPrimaryCharacter = x.IsPrimaryCharacter,
                 IsRetired = x.IsRetired,

--- a/api/ExpressedRealms.Characters.Repository/DTOs/CharacterListDto.cs
+++ b/api/ExpressedRealms.Characters.Repository/DTOs/CharacterListDto.cs
@@ -6,10 +6,6 @@ public sealed record CharacterListDto
 
     /// <example>John Doe</example>
     public string Name { get; set; } = null!;
-
-    /// <example>John Doe is a high elf from the northern woods.</example>
-    public string? Background { get; set; }
-
     /// <example>Adept</example>
     public string Expression { get; set; } = null!;
 

--- a/client/src/components/blessings/types.ts
+++ b/client/src/components/blessings/types.ts
@@ -25,7 +25,7 @@ export interface Blessing {
 
 export interface BlessingLevel {
   id: number
-  level: string
+  name: string
   description: string
   xpCost: number
   xpGain: number

--- a/client/src/components/characters/character/blessings/BlessingAccordion.vue
+++ b/client/src/components/characters/character/blessings/BlessingAccordion.vue
@@ -22,7 +22,7 @@ const props = defineProps({
         <div class="d-flex flex-column flex-grow-1 pr-3">
           <div class="d-flex flex-fill align-content-between d-block">
             <div class="flex-grow-1 font-bold text-900">
-              {{ item.name }}
+              {{ item.name }} - {{ item.levelName }}
             </div>
             <div>
               {{ item.subCategory }}

--- a/client/src/components/characters/character/stores/experienceBreakdownStore.ts
+++ b/client/src/components/characters/character/stores/experienceBreakdownStore.ts
@@ -49,12 +49,12 @@ export const experienceStore
               const optionalMaxXP = currentOptionalXp + response.data.availableDiscretionary
               let availableXp = optionalMaxXP - currentOptionalXp
 
-              if (requiredXp < xp.characterCreateMax && xp.sectionTypeId != XpSectionTypes.advantage) {
+              if (requiredXp < xp.characterCreateMax) {
                 availableXp = xp.characterCreateMax - requiredXp + optionalMaxXP
               }
 
-              if (xp.sectionTypeId == XpSectionTypes.advantage) {
-                availableXp = response.data.availableDiscretionary
+              if (xp.sectionTypeId == XpSectionTypes.advantage || xp.sectionTypeId == XpSectionTypes.disadvantage) {
+                availableXp = Math.min(xp.characterCreateMax - xp.total, response.data.availableDiscretionary)
               }
 
               if (characterInfo.isPrimaryCharacter && !characterInfo.isInCharacterCreation) {

--- a/client/src/components/characters/character/stores/experienceBreakdownStore.ts
+++ b/client/src/components/characters/character/stores/experienceBreakdownStore.ts
@@ -53,8 +53,12 @@ export const experienceStore
                 availableXp = xp.characterCreateMax - requiredXp + optionalMaxXP
               }
 
-              if (xp.sectionTypeId == XpSectionTypes.advantage || xp.sectionTypeId == XpSectionTypes.disadvantage) {
+              if (xp.sectionTypeId == XpSectionTypes.advantage) {
                 availableXp = Math.min(xp.characterCreateMax - xp.total, response.data.availableDiscretionary)
+              }
+
+              if (xp.sectionTypeId == XpSectionTypes.disadvantage) {
+                availableXp = xp.characterCreateMax - xp.total
               }
 
               if (characterInfo.isPrimaryCharacter && !characterInfo.isInCharacterCreation) {

--- a/client/src/components/characters/wizard/ShowXPCosts.vue
+++ b/client/src/components/characters/wizard/ShowXPCosts.vue
@@ -19,6 +19,11 @@ const props = defineProps({
     type: Number as unknown as () => XpSectionType,
     required: true,
   },
+  additionalAvailableXp: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
 })
 
 const xp = ref<CalculatedExperience>({})
@@ -55,7 +60,7 @@ watch(() => experienceInfo.calculatedValues, () => {
       <strong>Discretionary XP:</strong> {{ xp.currentOptionalXp }} / {{ xp.optionalMaxXP }}
     </div>
     <div>
-      <strong>Available XP:</strong> {{ xp.availableXp }}
+      <strong>Available XP:</strong> {{ xp.availableXp + props.additionalAvailableXp }}
     </div>
   </div>
   <div v-else class="d-flex flex-row justify-content-between gap-3">
@@ -68,7 +73,7 @@ watch(() => experienceInfo.calculatedValues, () => {
       <div class="d-flex flex-row justify-content-center gap-2">
         <div><strong>Available XP:</strong></div>
         <div v-if="characterInfo.isPrimaryCharacter">
-          {{ xp.availableXp }}
+          {{ xp.availableXp + props.additionalAvailableXp }}
         </div>
         <div v-else>
           <span class="material-symbols-outlined">all_inclusive</span>

--- a/client/src/components/characters/wizard/blessings/BlessingStep.vue
+++ b/client/src/components/characters/wizard/blessings/BlessingStep.vue
@@ -17,6 +17,7 @@ import ShowXPCosts from '@/components/characters/wizard/ShowXPCosts.vue'
 import { characterStore } from '@/components/characters/character/stores/characterStore.ts'
 import BlessingInfo from '@/components/characters/wizard/blessings/BlessingInfo.vue'
 import { breakpointsBootstrapV5, useBreakpoints } from '@vueuse/core'
+import Skeleton from 'primevue/skeleton'
 
 const route = useRoute()
 const store = blessingsStore()
@@ -107,45 +108,58 @@ const xpSectionType = computed(() => {
 </script>
 
 <template>
-  <Button label="Help" class="mb-2 float-end" @click="showAboutInfo" />
-
-  <div v-if="!selectedType && characterInfo.isInCharacterCreation">
-    No selected {{ props.type.toLowerCase() == 'advantage' ? 'advantages' : 'disadvantages' }} detected, please pick one below!
-  </div>
-  <div v-else-if="!selectedType && !characterInfo.isInCharacterCreation">
-    Below is a list of all available {{ props.type.toLowerCase() == 'advantage' ? 'advantages' : 'disadvantages' }}.
+  <div v-if="characterBlessingData.isLoading">
+    <Skeleton height="40px" />
+    <Skeleton height="30px" class="mt-3" />
+    <Skeleton height="30px" class="mt-3" />
+    <Skeleton height="40px" />
+    <Skeleton height="30px" class="mt-3" />
+    <Skeleton height="30px" class="mt-3" />
+    <Skeleton height="40px" />
+    <Skeleton height="30px" class="mt-3" />
+    <Skeleton height="30px" class="mt-3" />
   </div>
   <div v-else>
-    <h1>Selected {{ selectedType!.name }}s</h1>
-    <div v-for="trait in selectedType!.subCategories" :key="trait.name">
-      <h3 class="ml-3 pb-2">
-        {{ trait.name }}
-      </h3>
-      <div v-for="blessing in trait.blessings" :key="blessing.id">
-        <div class="ml-5 d-flex flex-column flex-md-row align-self-center justify-content-between">
-          <div>
-            <h3 class="p-0 m-0">
-              {{ blessing.name }}
-            </h3>
-          </div>
-          <div class="p-0 m-2">
-            <Button label="View" size="small" @click="updateWizardContent(blessing)" />
+    <Button label="Help" class="mb-2 float-end" @click="showAboutInfo" />
+
+    <div v-if="!selectedType && characterInfo.isInCharacterCreation">
+      No selected {{ props.type.toLowerCase() == 'advantage' ? 'advantages' : 'disadvantages' }} detected, please pick one below!
+    </div>
+    <div v-else-if="!selectedType && !characterInfo.isInCharacterCreation">
+      Below is a list of all available {{ props.type.toLowerCase() == 'advantage' ? 'advantages' : 'disadvantages' }}.
+    </div>
+    <div v-else>
+      <h1>Selected {{ selectedType!.name }}s</h1>
+      <div v-for="trait in selectedType!.subCategories" :key="trait.name">
+        <h3 class="ml-3 pb-2">
+          {{ trait.name }}
+        </h3>
+        <div v-for="blessing in trait.blessings" :key="blessing.id">
+          <div class="ml-5 d-flex flex-column flex-md-row align-self-center justify-content-between">
+            <div>
+              <h3 class="p-0 m-0">
+                {{ blessing.name }}
+              </h3>
+            </div>
+            <div class="p-0 m-2">
+              <Button label="View" size="small" @click="updateWizardContent(blessing)" />
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <h1 :id="makeIdSafe(currentType!.name)" class="pb-0 mb-0">
-    Available {{ currentType!.name }}s
-  </h1>
-  <ShowXPCosts v-if="characterInfo.isInCharacterCreation" :section-type="xpSectionType" />
-  <div v-for="subCategory in currentType!.subCategories" :key="subCategory.name">
-    <h2 :id="makeIdSafe(subCategory.name)" class="pl-md-3 pb-2">
-      {{ subCategory.name }}
-    </h2>
-    <div v-for="blessing in subCategory.blessings" :key="blessing.id">
-      <SelectBlessingItem :blessing="blessing" :is-read-only="props.isReadOnly" />
+    <h1 class="pb-0 mb-0">
+      Available {{ currentType!.name }}s
+    </h1>
+    <ShowXPCosts v-if="characterInfo.isInCharacterCreation" :section-type="xpSectionType" />
+    <div v-for="subCategory in currentType!.subCategories" :key="subCategory.name">
+      <h2 :id="makeIdSafe(subCategory.name)" class="pl-md-3 pb-2">
+        {{ subCategory.name }}
+      </h2>
+      <div v-for="blessing in subCategory.blessings" :key="blessing.id">
+        <SelectBlessingItem :blessing="blessing" :is-read-only="props.isReadOnly" />
+      </div>
     </div>
   </div>
 </template>

--- a/client/src/components/characters/wizard/blessings/BlessingStep.vue
+++ b/client/src/components/characters/wizard/blessings/BlessingStep.vue
@@ -105,6 +105,11 @@ const xpSectionType = computed(() => {
   return props.type.toLowerCase() == 'disadvantage' ? XpSectionTypes.disadvantage : XpSectionTypes.advantage
 })
 
+function getBlessingLevelName(blessing: Blessing) {
+  const currentBlessing = characterBlessingData.blessings.find(x => x.blessingId == blessing?.id)
+  return blessing.levels.find(x => x.id == currentBlessing.blessingLevelId).name
+}
+
 </script>
 
 <template>
@@ -134,14 +139,14 @@ const xpSectionType = computed(() => {
         <h3 class="ml-3 pb-2">
           {{ trait.name }}
         </h3>
-        <div v-for="blessing in trait.blessings" :key="blessing.id">
-          <div class="ml-5 d-flex flex-column flex-md-row align-self-center justify-content-between">
+        <div v-for="blessing in trait.blessings" :key="blessing.id" class="mb-3">
+          <div class="pl-5 d-flex flex-row align-self-center justify-content-between">
             <div>
               <h3 class="p-0 m-0">
-                {{ blessing.name }}
+                {{ blessing.name }} - {{ getBlessingLevelName(blessing) }}
               </h3>
             </div>
-            <div class="p-0 m-2">
+            <div class="p-0">
               <Button label="View" size="small" @click="updateWizardContent(blessing)" />
             </div>
           </div>

--- a/client/src/components/characters/wizard/blessings/stores/characterBlessingStore.ts
+++ b/client/src/components/characters/wizard/blessings/stores/characterBlessingStore.ts
@@ -29,7 +29,6 @@ export const characterBlessingsStore
     },
     actions: {
       async getCharacterBlessings(characterId: number) {
-        this.isLoading = true
         const response = await axios.get<CharacterBlessingsBaseResponse>(`/characters/${characterId}/blessings`)
 
         const selectedIds = response.data.blessings.map(x => x.blessingId)

--- a/client/src/components/characters/wizard/blessings/supports/AddCharacterBlessing.vue
+++ b/client/src/components/characters/wizard/blessings/supports/AddCharacterBlessing.vue
@@ -24,7 +24,6 @@ const experienceInfo = experienceStore()
 const characterInfo = characterStore()
 
 const availableXp = ref(0)
-const spentXp = ref(0)
 
 const props = defineProps({
   blessing: {
@@ -47,17 +46,11 @@ const onSubmit = form.handleSubmit(async (values) => {
 })
 
 function disableOption(level: BlessingLevel) {
-  if (props.blessing.type.toLowerCase() == 'disadvantage') {
-    return level.xpGain > availableXp.value
-  }
-  return level.xpCost > availableXp.value
+  return getCost(level) > availableXp.value
 }
 
 const cannotMeetMinimumLevel = computed(() => {
-  let minimumLevelCost = props.blessing.levels[0].xpCost
-  if (props.blessing.type.toLowerCase() == 'disadvantage') {
-    minimumLevelCost = props.blessing.levels[0].xpGain
-  }
+  let minimumLevelCost = getCost(props.blessing.levels[0])
   return availableXp.value < minimumLevelCost
 })
 
@@ -68,6 +61,10 @@ function updateLevel(level: BlessingLevel) {
 const xpSectionType = computed(() => {
   return props.blessing.type.toLowerCase() == 'disadvantage' ? XpSectionTypes.disadvantage : XpSectionTypes.advantage
 })
+
+function getCost(level: BlessingLevel) {
+  return props.blessing.type.toLowerCase() == 'disadvantage' ? level.xpGain : level.xpCost
+}
 
 </script>
 
@@ -98,7 +95,7 @@ const xpSectionType = computed(() => {
     <div v-for="level in props.blessing.levels" :key="level.id" class="mt-3">
       <div class="d-flex flex-column flex-md-row align-self-center">
         <RadioButton :input-id="level.id.toString()" :value="level" class="mr-4" :disabled="disableOption(level) || !characterInfo.isInCharacterCreation" @click="updateLevel(level)" />
-        <label :for="level.id.toString()" :class="disableOption(level) ? 'non-selectable' : ''">{{ level.name }} – {{ level.description }}</label>
+        <label :for="level.id.toString()" :class="disableOption(level) ? 'non-selectable' : ''">-{{ Math.abs(getCost(level)) }} xp - {{ level.name }} – {{ level.description }}</label>
       </div>
     </div>
 

--- a/client/src/components/characters/wizard/blessings/supports/AddCharacterBlessing.vue
+++ b/client/src/components/characters/wizard/blessings/supports/AddCharacterBlessing.vue
@@ -80,14 +80,14 @@ function getCost(level: BlessingLevel) {
       You may only modify this {{ props.blessing.type.toLowerCase() }} during character creation.
     </Message>
   </div>
-  <div v-else-if="availableXp == 0">
-    <Message severity="warn" class="mt-4">
-      You've spent all the XP you can on {{ props.blessing.type.toLowerCase() }}s.
-    </Message>
-  </div>
   <div v-else-if="cannotMeetMinimumLevel">
     <Message severity="warn" class="mt-4">
       Your available XP does not match the minimum level for this {{ props.blessing.type.toLowerCase() }}.
+    </Message>
+  </div>
+  <div v-else-if="availableXp == 0">
+    <Message severity="warn" class="mt-4">
+      You've spent all the XP you can on {{ props.blessing.type.toLowerCase() }}s.
     </Message>
   </div>
 

--- a/client/src/components/characters/wizard/blessings/supports/AddCharacterBlessing.vue
+++ b/client/src/components/characters/wizard/blessings/supports/AddCharacterBlessing.vue
@@ -24,6 +24,7 @@ const experienceInfo = experienceStore()
 const characterInfo = characterStore()
 
 const availableXp = ref(0)
+const spentXp = ref(0)
 
 const props = defineProps({
   blessing: {
@@ -35,12 +36,8 @@ const props = defineProps({
 watch(() => props.blessing, async () => {
   let sectionType: XpSectionType = props.blessing.type.toLowerCase() == 'disadvantage' ? XpSectionTypes.disadvantage : XpSectionTypes.advantage
   let xpInfo = experienceInfo.getExperienceInfoForSection(sectionType)
-  if (sectionType == XpSectionTypes.advantage) {
-    availableXp.value = xpInfo.availableXp
-  }
-  else {
-    availableXp.value = xpInfo.characterCreateMax - xpInfo.total
-  }
+
+  availableXp.value = xpInfo.availableXp
 
   form.customResetForm()
 }, { immediate: true })
@@ -55,6 +52,14 @@ function disableOption(level: BlessingLevel) {
   }
   return level.xpCost > availableXp.value
 }
+
+const cannotMeetMinimumLevel = computed(() => {
+  let minimumLevelCost = props.blessing.levels[0].xpCost
+  if (props.blessing.type.toLowerCase() == 'disadvantage') {
+    minimumLevelCost = props.blessing.levels[0].xpGain
+  }
+  return availableXp.value < minimumLevelCost
+})
 
 function updateLevel(level: BlessingLevel) {
   form.blessingLevel.field.value = level
@@ -73,11 +78,22 @@ const xpSectionType = computed(() => {
 
   <div v-html="props.blessing?.description" />
   <ShowXPCosts v-if="characterInfo.isInCharacterCreation" :section-type="xpSectionType" class="pt-3" />
-  <div v-if="availableXp == 0">
+  <div v-if="!characterInfo.isInCharacterCreation">
     <Message severity="warn" class="mt-4">
-      You do not have enough experience to add this to your character.
+      You may only modify this {{ props.blessing.type.toLowerCase() }} during character creation.
     </Message>
   </div>
+  <div v-else-if="availableXp == 0">
+    <Message severity="warn" class="mt-4">
+      You've spent all the XP you can on {{ props.blessing.type.toLowerCase() }}s.
+    </Message>
+  </div>
+  <div v-else-if="cannotMeetMinimumLevel">
+    <Message severity="warn" class="mt-4">
+      Your available XP does not match the minimum level for this {{ props.blessing.type.toLowerCase() }}.
+    </Message>
+  </div>
+
   <form @submit="onSubmit">
     <div v-for="level in props.blessing.levels" :key="level.id" class="mt-3">
       <div class="d-flex flex-column flex-md-row align-self-center">

--- a/client/src/components/characters/wizard/blessings/supports/EditCharacterBlessing.vue
+++ b/client/src/components/characters/wizard/blessings/supports/EditCharacterBlessing.vue
@@ -35,9 +35,10 @@ const props = defineProps({
 const mappingId = ref(0)
 const currentLevel = ref<BlessingLevel>({})
 const currentCost = computed(() => {
-  return props.blessing.type.toLowerCase() == 'disadvantage' ? currentLevel.value.xpGain : currentLevel.value.xpCost
+  return getCost(currentLevel.value)
 })
 const availableXp = ref(0)
+const spentXp = ref(0)
 
 const loadData = async () => {
   const currentBlessing = store.blessings.find(x => x.blessingId == props.blessing?.id)
@@ -46,6 +47,7 @@ const loadData = async () => {
   form.setValues(currentBlessing, currentLevel.value)
   let sectionType: XpSectionType = props.blessing.type.toLowerCase() == 'disadvantage' ? XpSectionTypes.disadvantage : XpSectionTypes.advantage
   let xpInfo = experienceInfo.getExperienceInfoForSection(sectionType)
+  spentXp.value = xpInfo.total
   availableXp.value = xpInfo.availableXp + currentCost.value
 }
 
@@ -56,19 +58,17 @@ watch(() => props.blessing.id, async () => {
 const onSubmit = form.handleSubmit(async (values) => {
   const currentBlessing = store.blessings.filter(x => x.blessingId == props.blessing?.id)[0]
   await store.updateBlessing(values, route.params.id, currentBlessing.id)
+  await loadData()
 })
 
 function disableOption(level: BlessingLevel) {
-  if (props.blessing.type.toLowerCase() == 'disadvantage') {
-    return level.xpGain > availableXp.value && level.xpGain > currentLevel.value.xpGain
-  }
-  return level.xpCost > availableXp.value && level.xpCost > currentLevel.value.xpCost
+  return getCost(level) > availableXp.value && getCost(level) > getCost(currentLevel.value)
 }
 
 const canOnlyDelete = computed(() => {
   const levelId = form.blessingLevel.field.value?.id ?? -1
   let indexLevel = props.blessing.levels.findIndex(x => x.id === levelId)
-  return indexLevel == 0 && availableXp.value == 0
+  return indexLevel == 0 && insuffecientXpToUpgrade.value
 })
 
 const canLowerOrDelete = computed(() => {
@@ -77,9 +77,26 @@ const canLowerOrDelete = computed(() => {
   return indexLevel > 0
 })
 
+const insuffecientXpToUpgrade = computed(() => {
+  const levelId = form.blessingLevel.field.value?.id ?? -1
+  let indexLevel = props.blessing.levels.findIndex(x => x.id === levelId)
+
+  if (indexLevel == props.blessing.levels.length - 1) return false
+
+  const nextLevelXp = getCost(props.blessing.levels[indexLevel + 1])
+  const currentLevelXp = getCost(props.blessing.levels[indexLevel])
+
+  let diffBetweenLevels = nextLevelXp - currentLevelXp
+  return diffBetweenLevels > availableXp.value - currentCost.value
+})
+
 const xpSectionType = computed(() => {
   return props.blessing.type.toLowerCase() == 'disadvantage' ? XpSectionTypes.disadvantage : XpSectionTypes.advantage
 })
+
+function getCost(level: BlessingLevel) {
+  return props.blessing.type.toLowerCase() == 'disadvantage' ? level.xpGain : level.xpCost
+}
 
 </script>
 
@@ -98,16 +115,10 @@ const xpSectionType = computed(() => {
     </div>
 
     <div v-html="props.blessing?.description" />
-    <ShowXPCosts v-if="characterInfo.isInCharacterCreation" :section-type="xpSectionType" class="pt-3" :additional-available-xp="currentCost" />
+    <ShowXPCosts v-if="characterInfo.isInCharacterCreation" :section-type="xpSectionType" class="pt-3" />
     <div v-if="!characterInfo.isInCharacterCreation">
       <Message severity="warn" class="mt-4">
         You may only modify this {{ props.blessing.type.toLowerCase() }} during character creation.
-      </Message>
-    </div>
-    <div v-else-if="canLowerOrDelete">
-      <Message severity="warn" class="mt-4">
-        You may lower the level of this {{ props.blessing.type.toLowerCase() }} or delete it, but you cannot increase it
-        due to insufficient XP.
       </Message>
     </div>
     <div v-else-if="canOnlyDelete">
@@ -115,10 +126,23 @@ const xpSectionType = computed(() => {
         You may only delete this {{ props.blessing.type.toLowerCase() }}.
       </Message>
     </div>
+    <div v-else-if="canLowerOrDelete && spentXp == 8">
+      <Message severity="warn" class="mt-4">
+        You may lower the level of this {{ props.blessing.type.toLowerCase() }} or delete it.  You have spent all available points on
+        {{ props.blessing.type.toLowerCase() }}s.
+      </Message>
+    </div>
+    <div v-else-if="insuffecientXpToUpgrade">
+      <Message severity="warn" class="mt-4">
+        You may lower the level of this {{ props.blessing.type.toLowerCase() }} or delete it, but you cannot increase it
+        due to insufficient XP.
+      </Message>
+    </div>
+
     <div v-for="level in props.blessing.levels" :key="level.id" class="mt-3">
       <div class="d-flex flex-column flex-md-row align-self-center">
         <RadioButton v-model="form.blessingLevel.field.value" :input-id="level.id.toString()" :value="level" class="mr-4" :disabled="disableOption(level) || !characterInfo.isInCharacterCreation" />
-        <label :for="level.id.toString()" :class="disableOption(level) ? 'non-selectable' : ''">{{ level.name }} – {{ level.description }}</label>
+        <label :for="level.id.toString()" :class="disableOption(level) ? 'non-selectable' : ''">{{ getCost(level) > currentCost ? "-" : "+" }}{{ Math.abs(getCost(level) - currentCost) }} xp – {{ level.name }} – {{ level.description }}</label>
       </div>
     </div>
 

--- a/client/src/components/characters/wizard/blessings/supports/EditCharacterBlessing.vue
+++ b/client/src/components/characters/wizard/blessings/supports/EditCharacterBlessing.vue
@@ -3,7 +3,7 @@
 import FormTextAreaWrapper from '@/FormWrappers/FormTextAreaWrapper.vue'
 import Button from 'primevue/button'
 import { useRoute } from 'vue-router'
-import { computed, onBeforeMount, type PropType, ref, watch } from 'vue'
+import { computed, type PropType, ref, watch } from 'vue'
 import type { Blessing, BlessingLevel } from '@/components/blessings/types.ts'
 import RadioButton from 'primevue/radiobutton'
 import { getValidationInstance } from '@/components/characters/wizard/blessings/validators/blessingValidations.ts'
@@ -34,32 +34,24 @@ const props = defineProps({
 
 const mappingId = ref(0)
 const currentLevel = ref<BlessingLevel>({})
+const currentCost = computed(() => {
+  return props.blessing.type.toLowerCase() == 'disadvantage' ? currentLevel.value.xpGain : currentLevel.value.xpCost
+})
 const availableXp = ref(0)
 
-onBeforeMount(async () => {
-  await loadData()
-})
-
-watch(() => props.blessing, async () => {
-  await loadData()
-})
-
 const loadData = async () => {
-  const currentBlessing = store.blessings.filter(x => x.blessingId == props.blessing?.id)[0]
-  currentLevel.value = props.blessing.levels.filter(x => x.id == currentBlessing.blessingLevelId)[0]
+  const currentBlessing = store.blessings.find(x => x.blessingId == props.blessing?.id)
+  currentLevel.value = props.blessing.levels.find(x => x.id == currentBlessing.blessingLevelId) ?? {}
   mappingId.value = currentBlessing.id
   form.setValues(currentBlessing, currentLevel.value)
   let sectionType: XpSectionType = props.blessing.type.toLowerCase() == 'disadvantage' ? XpSectionTypes.disadvantage : XpSectionTypes.advantage
   let xpInfo = experienceInfo.getExperienceInfoForSection(sectionType)
-  let currentLevelXp = props.blessing.type.toLowerCase() == 'disadvantage' ? currentLevel.value.xpGain : currentLevel.value.xpCost
-
-  if (sectionType == XpSectionTypes.advantage) {
-    availableXp.value = xpInfo.availableXp
-  }
-  else {
-    availableXp.value = xpInfo.characterCreateMax - xpInfo.total + currentLevelXp
-  }
+  availableXp.value = xpInfo.availableXp + currentCost.value
 }
+
+watch(() => props.blessing.id, async () => {
+  await loadData()
+}, { immediate: true })
 
 const onSubmit = form.handleSubmit(async (values) => {
   const currentBlessing = store.blessings.filter(x => x.blessingId == props.blessing?.id)[0]
@@ -72,6 +64,18 @@ function disableOption(level: BlessingLevel) {
   }
   return level.xpCost > availableXp.value && level.xpCost > currentLevel.value.xpCost
 }
+
+const canOnlyDelete = computed(() => {
+  const levelId = form.blessingLevel.field.value?.id ?? -1
+  let indexLevel = props.blessing.levels.findIndex(x => x.id === levelId)
+  return indexLevel == 0 && availableXp.value == 0
+})
+
+const canLowerOrDelete = computed(() => {
+  const levelId = form.blessingLevel.field.value?.id ?? -1
+  let indexLevel = props.blessing.levels.findIndex(x => x.id === levelId)
+  return indexLevel > 0
+})
 
 const xpSectionType = computed(() => {
   return props.blessing.type.toLowerCase() == 'disadvantage' ? XpSectionTypes.disadvantage : XpSectionTypes.advantage
@@ -94,15 +98,26 @@ const xpSectionType = computed(() => {
     </div>
 
     <div v-html="props.blessing?.description" />
-    <ShowXPCosts v-if="characterInfo.isInCharacterCreation" :section-type="xpSectionType" class="pt-3" />
-    <div v-if="availableXp == 0">
+    <ShowXPCosts v-if="characterInfo.isInCharacterCreation" :section-type="xpSectionType" class="pt-3" :additional-available-xp="currentCost" />
+    <div v-if="!characterInfo.isInCharacterCreation">
       <Message severity="warn" class="mt-4">
-        You do not have enough experience to modify this.
+        You may only modify this {{ props.blessing.type.toLowerCase() }} during character creation.
+      </Message>
+    </div>
+    <div v-else-if="canLowerOrDelete">
+      <Message severity="warn" class="mt-4">
+        You may lower the level of this {{ props.blessing.type.toLowerCase() }} or delete it, but you cannot increase it
+        due to insufficient XP.
+      </Message>
+    </div>
+    <div v-else-if="canOnlyDelete">
+      <Message severity="warn" class="mt-4">
+        You may only delete this {{ props.blessing.type.toLowerCase() }}.
       </Message>
     </div>
     <div v-for="level in props.blessing.levels" :key="level.id" class="mt-3">
       <div class="d-flex flex-column flex-md-row align-self-center">
-        <RadioButton v-model="form.blessingLevel.field" :input-id="level.id.toString()" :value="level" class="mr-4" :disabled="disableOption(level) || !characterInfo.isInCharacterCreation" />
+        <RadioButton v-model="form.blessingLevel.field.value" :input-id="level.id.toString()" :value="level" class="mr-4" :disabled="disableOption(level) || !characterInfo.isInCharacterCreation" />
         <label :for="level.id.toString()" :class="disableOption(level) ? 'non-selectable' : ''">{{ level.name }} – {{ level.description }}</label>
       </div>
     </div>


### PR DESCRIPTION
 - Advantages will now correctly pull from only discretionary on the front end
 - Advantages will now correctly cap to either 8 points or the max available discretionary available, not 8 + available discretionary
 - Disadvantages will also no longer do that, and only check against it's own cap
 - Added xp to the descriptions, it's the only way to have it make sense with the other parts of the wizard
 - Added skeleton for initial load of the page
 - Add now has the following messages
   - You can only modify this {ad/disad} during character creation.
   - Your available XP does not match the minimum level for this {ad/disad}
   - You've spent all the XP you can on {ad/disad}s
 - Edit now has the following messages
   - You may only modify this  {ad/disad} during character creation.
   - You may only delete this  {ad/disad}.
   - You may lower the level of this {ad/disad} or delete it.  You have spent all available points on  {ad/disad}s.
   - You may lower the level of this {ad/disad} or delete it, but you cannot increase it  due to insufficient XP.
 - Character List will now load a lot faster - removed the background info from being loaded in on the tiles page