### PR TITLE
Add Caching and Compression

### DIFF
--- a/api/ExpressedRealms.Expressions.API/ExpressionSubSectionEndpoints/ExpressionSubSectionsEndpoints.cs
+++ b/api/ExpressedRealms.Expressions.API/ExpressionSubSectionEndpoints/ExpressionSubSectionsEndpoints.cs
@@ -8,6 +8,7 @@ using ExpressedRealms.Server.Shared;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Extensions;
 using ExpressionSectionDto = ExpressedRealms.Expressions.API.ExpressionSubSectionEndpoints.DTOs.ExpressionSectionDto;
 using SectionTypeDto = ExpressedRealms.Expressions.API.ExpressionSubSectionEndpoints.DTOs.SectionTypeDto;
@@ -67,6 +68,7 @@ internal static class ExpectedSubSectionsEndpoints
                     );
                 }
             )
+            .CacheOutput(builder => builder.Expire(TimeSpan.FromMinutes(20)))
             .RequireAuthorization();
 
         endpointGroup

--- a/api/ExpressedRealms.Powers.API/PowerPathEndpoints/PowerPathEndpoints.cs
+++ b/api/ExpressedRealms.Powers.API/PowerPathEndpoints/PowerPathEndpoints.cs
@@ -13,6 +13,7 @@ using ExpressedRealms.Server.Shared;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Extensions;
 using DetailedInformation = ExpressedRealms.Powers.API.PowerEndpoints.Responses.PowerList.DetailedInformation;
 
@@ -75,6 +76,7 @@ internal static class PowerPathEndpoints
                     );
                 }
             )
+            .CacheOutput(builder => builder.Expire(TimeSpan.FromMinutes(20)))
             .WithSummary("Returns the list of power paths for a given expression")
             .RequireAuthorization();
 

--- a/api/ExpressedRealms.Server/Program.cs
+++ b/api/ExpressedRealms.Server/Program.cs
@@ -40,6 +40,7 @@ using ExpressedRealms.Shared.AzureKeyVault.Secrets;
 using ExpressedRealms.Shared.Configuration;
 using FluentValidation;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Scalar.AspNetCore;
 using Serilog;
@@ -137,6 +138,7 @@ try
     {
         options.Level = CompressionLevel.Fastest;
     });
+    builder.Services.AddOutputCache();
 
     builder.Services.AddHttpContextAccessor();
     // https://stackoverflow.com/questions/64122616/cancellation-token-injection/77342914#77342914

--- a/api/ExpressedRealms.Server/Program.cs
+++ b/api/ExpressedRealms.Server/Program.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Audit.Core;
 using Azure.Identity;
 using ExpressedRealms.Admin.API.Configuration;
@@ -119,6 +120,23 @@ try
     builder.Services.AddValidatorsFromAssemblyContaining<Program>();
     builder.Services.AddFluentValidationAutoValidation();
     builder.Services.AddSingleton<ITelemetryInitializer, RouteTemplateTelemetryInitializer>();
+    builder.Services.AddResponseCompression(options =>
+    {
+        options.EnableForHttps = true;
+         
+        options.Providers.Add<GzipCompressionProvider>();
+        options.Providers.Add<BrotliCompressionProvider>();
+    });
+
+    builder.Services.Configure<BrotliCompressionProviderOptions>(options =>
+    {
+        options.Level = CompressionLevel.Fastest;
+    });
+
+    builder.Services.Configure<GzipCompressionProviderOptions>(options =>
+    {
+        options.Level = CompressionLevel.Fastest;
+    });
 
     builder.Services.AddHttpContextAccessor();
     // https://stackoverflow.com/questions/64122616/cancellation-token-injection/77342914#77342914
@@ -212,6 +230,8 @@ try
     // Seed Roles
     await app.ConfigureUserRoles();
 
+    app.UseResponseCompression();
+    app.UseOutputCache();
     app.UseDefaultFiles();
     app.UseStaticFiles();
 

--- a/api/ExpressedRealms.Server/Program.cs
+++ b/api/ExpressedRealms.Server/Program.cs
@@ -124,7 +124,7 @@ try
     builder.Services.AddResponseCompression(options =>
     {
         options.EnableForHttps = true;
-         
+
         options.Providers.Add<GzipCompressionProvider>();
         options.Providers.Add<BrotliCompressionProvider>();
     });

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -85,7 +85,11 @@ const app = createApp(App)
 app.directive('ripple', Ripple)
 app.directive('tooltip', Tooltip)
 app.use(pinia)
-app.use(PiniaColada)
+app.use(PiniaColada, {
+  queryOptions: {
+    staleTime: Infinity,
+  },
+})
 app.use(ToastService)
 app.use(ConfirmationService)
 app.use(DialogService)


### PR DESCRIPTION
Compression 
 - This should have been enabled a long time ago, does a very good job on the expression pages, reducing the size of those loads.  One of the text heavy end points went from 83kb to 21kb

Cached Expression, Powers, Rule Book, and World Background server endpoints
 - For 20 minutes at a time server side
 - This will help with much faster load times
 - Doing this gets sub 10 second response times

Pinia Colada will no longer Expire
 - It must now be done explicitly