### PR TITLE
Hotfix crb and knowledges

### DIFF
--- a/api/ExpressedRealms.Characters.Reports/CRB/CharacterReferenceBookletReport.cs
+++ b/api/ExpressedRealms.Characters.Reports/CRB/CharacterReferenceBookletReport.cs
@@ -409,7 +409,7 @@ public static class CharacterReferenceBookletReport
         );
         TextPrintUtilities.PrintStatInfo(
             page,
-            dataProficiencyInfo.Throw.ToString(),
+            dataProficiencyInfo.EvadeThrow.ToString(),
             XUnitPt.FromInch(2.63),
             XUnitPt.FromInch(7.60)
         );

--- a/client/src/components/characters/wizard/knowledges/EditCharacterKnowledge.vue
+++ b/client/src/components/characters/wizard/knowledges/EditCharacterKnowledge.vue
@@ -54,8 +54,17 @@ async function loadInfo() {
   sectionInfo.value = xpInfo.getExperienceInfoForSection(XpSectionTypes.knowledges)
 
   store.knowledgeLevels.map(function (level: KnowledgeOptions) {
-    const xpCost = isUnknownKnowledge.value ? level.totalUnknownXpCost : level.totalGeneralXpCost
+    var index = store.knowledgeLevels.indexOf(level)
     const isLowerLevel = level.id > knowledge.value.levelId
+
+    let xpCost = 0
+    if (index === 0) {
+      xpCost = level.totalGeneralXpCost
+    }
+    else {
+      xpCost = level.totalGeneralXpCost - getCurrentXpLevel(knowledge.value.levelId)
+    }
+
     level.disabled = xpCost > sectionInfo.value.availableXp && isLowerLevel
     return level
   })


### PR DESCRIPTION
If XP is equal to knowledge level, you can now purchase it
in CRB, Throw Evade is no longer just throw