### PR TITLE
Rework Stat Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -407,3 +407,6 @@ megalinter-reports/
 
 # Cypress test reports for github
 client/cypress/results
+
+# k6 Secrets file
+k6/secrets.ts

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/CharacterEndPoints.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/CharacterEndPoints.cs
@@ -329,11 +329,17 @@ internal static class CharacterEndPoints
         endpointGroup.MapPut("{id}", EditCharacterEndpoint.Execute).RequireAuthorization();
 
         endpointGroup
-            .MapGet("{characterId}/stat/{statTypeId}",GetDetailedStatInfoForCharacterEndpoint.ExecuteAsync)
+            .MapGet(
+                "{characterId}/stat/{statTypeId}",
+                GetDetailedStatInfoForCharacterEndpoint.ExecuteAsync
+            )
             .RequireAuthorization();
 
         endpointGroup
-            .MapPut("{characterId}/stat/{statTypeId}", EditStatInfoForCharacterEndpoint.ExecuteAsync)
+            .MapPut(
+                "{characterId}/stat/{statTypeId}",
+                EditStatInfoForCharacterEndpoint.ExecuteAsync
+            )
             .RequireAuthorization();
 
         endpointGroup

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/CharacterEndPoints.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/CharacterEndPoints.cs
@@ -330,11 +330,11 @@ internal static class CharacterEndPoints
         endpointGroup.MapPut("{id}", EditCharacterEndpoint.Execute).RequireAuthorization();
 
         endpointGroup
-            .MapGet("{characterId}/stat/{statTypeId}",GetDetailedStatInfoForCharacter.ExecuteAsync)
+            .MapGet("{characterId}/stat/{statTypeId}",GetDetailedStatInfoForCharacterEndpoint.ExecuteAsync)
             .RequireAuthorization();
 
         endpointGroup
-            .MapPut("{characterId}/stat/{statTypeId}", EditStatInfoForCharacter.ExecuteAsync)
+            .MapPut("{characterId}/stat/{statTypeId}", EditStatInfoForCharacterEndpoint.ExecuteAsync)
             .RequireAuthorization();
 
         endpointGroup

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/CharacterEndPoints.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/CharacterEndPoints.cs
@@ -11,6 +11,7 @@ using ExpressedRealms.Characters.API.CharacterEndPoints.GetBreakOfDawnInfo;
 using ExpressedRealms.Characters.API.CharacterEndPoints.GetCRB;
 using ExpressedRealms.Characters.API.CharacterEndPoints.GetDetailedStatInfo;
 using ExpressedRealms.Characters.API.CharacterEndPoints.GetOverallStats;
+using ExpressedRealms.Characters.API.CharacterEndPoints.GetStatsForCharacter;
 using ExpressedRealms.Characters.API.CharacterEndPoints.Requests;
 using ExpressedRealms.Characters.API.CharacterEndPoints.Responses;
 using ExpressedRealms.Characters.API.CharacterEndPoints.RetireCharacter;
@@ -19,7 +20,6 @@ using ExpressedRealms.Characters.Repository.DTOs;
 using ExpressedRealms.Characters.Repository.Enums;
 using ExpressedRealms.Characters.Repository.Skills;
 using ExpressedRealms.Characters.Repository.Skills.DTOs;
-using ExpressedRealms.Characters.Repository.Stats;
 using ExpressedRealms.DB;
 using ExpressedRealms.Expressions.Repository.Expressions;
 using ExpressedRealms.FeatureFlags;
@@ -31,7 +31,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Extensions;
-using SmallStatInfo = ExpressedRealms.Characters.API.StatEndPoints.Responses.SmallStatInfo;
 
 namespace ExpressedRealms.Characters.API.CharacterEndPoints;
 
@@ -338,26 +337,7 @@ internal static class CharacterEndPoints
             .RequireAuthorization();
 
         endpointGroup
-            .MapGet(
-                "{characterId}/stats",
-                [Authorize]
-                async Task<Results<NotFound, Ok<List<SmallStatInfo>>>> (
-                    int characterId,
-                    ICharacterStatRepository repository
-                ) =>
-                {
-                    var results = await repository.GetAllStats(characterId);
-
-                    if (results.HasNotFound(out var notFound))
-                        return notFound;
-                    results.ThrowIfErrorNotHandled();
-
-                    return TypedResults.Ok(
-                        results.Value.Select(x => new SmallStatInfo(x)).ToList()
-                    );
-                }
-            )
-            .WithSummary("Returns the info needed for displaying the small stat tiles")
+            .MapGet("{characterId}/stats", GetStatsForCharacterEndpoint.ExecuteAsync)
             .WithDescription(
                 "Returns the info needed for displaying the small stat tiles, mainly the bonus, stat name and level."
             )

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/CharacterEndPoints.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/CharacterEndPoints.cs
@@ -4,23 +4,22 @@ using ExpressedRealms.Characters.API.CharacterEndPoints.CopyCharacter;
 using ExpressedRealms.Characters.API.CharacterEndPoints.DTOs;
 using ExpressedRealms.Characters.API.CharacterEndPoints.EditCharacter;
 using ExpressedRealms.Characters.API.CharacterEndPoints.EditCharacterOptions;
+using ExpressedRealms.Characters.API.CharacterEndPoints.EditStatInfo;
 using ExpressedRealms.Characters.API.CharacterEndPoints.FinalizeCharacterCreate;
 using ExpressedRealms.Characters.API.CharacterEndPoints.GetArchetypesForExpression;
 using ExpressedRealms.Characters.API.CharacterEndPoints.GetBreakOfDawnInfo;
 using ExpressedRealms.Characters.API.CharacterEndPoints.GetCRB;
+using ExpressedRealms.Characters.API.CharacterEndPoints.GetDetailedStatInfo;
 using ExpressedRealms.Characters.API.CharacterEndPoints.GetOverallStats;
 using ExpressedRealms.Characters.API.CharacterEndPoints.Requests;
 using ExpressedRealms.Characters.API.CharacterEndPoints.Responses;
 using ExpressedRealms.Characters.API.CharacterEndPoints.RetireCharacter;
-using ExpressedRealms.Characters.API.StatEndPoints.Requests;
 using ExpressedRealms.Characters.Repository;
 using ExpressedRealms.Characters.Repository.DTOs;
 using ExpressedRealms.Characters.Repository.Enums;
 using ExpressedRealms.Characters.Repository.Skills;
 using ExpressedRealms.Characters.Repository.Skills.DTOs;
 using ExpressedRealms.Characters.Repository.Stats;
-using ExpressedRealms.Characters.Repository.Stats.DTOs;
-using ExpressedRealms.Characters.Repository.Stats.Enums;
 using ExpressedRealms.DB;
 using ExpressedRealms.Expressions.Repository.Expressions;
 using ExpressedRealms.FeatureFlags;
@@ -32,7 +31,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Extensions;
-using SingleStatInfo = ExpressedRealms.Characters.API.CharacterEndPoints.StatDTOs.SingleStatInfo;
 using SmallStatInfo = ExpressedRealms.Characters.API.StatEndPoints.Responses.SmallStatInfo;
 
 namespace ExpressedRealms.Characters.API.CharacterEndPoints;
@@ -332,65 +330,11 @@ internal static class CharacterEndPoints
         endpointGroup.MapPut("{id}", EditCharacterEndpoint.Execute).RequireAuthorization();
 
         endpointGroup
-            .MapGet(
-                "{characterId}/stat/{statTypeId}",
-                [Authorize]
-                async Task<Results<NotFound, ValidationProblem, Ok<SingleStatInfo>>> (
-                    int characterId,
-                    StatType statTypeId,
-                    ICharacterStatRepository repository
-                ) =>
-                {
-                    var results = await repository.GetDetailedStatInfo(
-                        new GetDetailedStatInfoDto(characterId, statTypeId)
-                    );
-
-                    if (results.HasNotFound(out var notFound))
-                        return notFound;
-                    if (results.HasValidationError(out var validationProblem))
-                        return validationProblem;
-                    results.ThrowIfErrorNotHandled();
-
-                    return TypedResults.Ok(new SingleStatInfo(results.Value));
-                }
-            )
-            .WithSummary("This returns the detailed information for the given stat")
-            .WithDescription(
-                "This returns the detailed information for the given stat.  This will include the full name, what it does, current level, bonus, xp, and description."
-            )
+            .MapGet("{characterId}/stat/{statTypeId}",GetDetailedStatInfoForCharacter.ExecuteAsync)
             .RequireAuthorization();
 
         endpointGroup
-            .MapPut(
-                "{characterId}/stat/{statTypeId}",
-                [Authorize]
-                async Task<Results<NotFound, NoContent, ValidationProblem, BadRequest<string>>> (
-                    EditStatRequest request,
-                    ICharacterStatRepository repository
-                ) =>
-                {
-                    var results = await repository.UpdateCharacterStat(
-                        new EditStatDto()
-                        {
-                            CharacterId = request.CharacterId,
-                            LevelTypeId = request.LevelTypeId,
-                            StatTypeId = request.StatTypeId,
-                        }
-                    );
-
-                    if (results.HasNotFound(out var notFound))
-                        return notFound;
-                    if (results.HasValidationError(out var validationProblem))
-                        return validationProblem;
-                    if (results.HasInsufficientXP(out var insufficientXPMessage))
-                        return insufficientXPMessage;
-                    results.ThrowIfErrorNotHandled();
-
-                    return TypedResults.NoContent();
-                }
-            )
-            .WithSummary("Allows user to update the given state with the provided level")
-            .WithDescription("Allows user to update the given state with the provided level")
+            .MapPut("{characterId}/stat/{statTypeId}", EditStatInfoForCharacter.ExecuteAsync)
             .RequireAuthorization();
 
         endpointGroup

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/EditStatInfo/EditStatInfoForCharacter.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/EditStatInfo/EditStatInfoForCharacter.cs
@@ -1,0 +1,39 @@
+using ExpressedRealms.Characters.API.StatEndPoints.Requests;
+using ExpressedRealms.Characters.Repository.Stats;
+using ExpressedRealms.Characters.Repository.Stats.DTOs;
+using ExpressedRealms.Characters.Repository.Stats.Enums;
+using ExpressedRealms.Server.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace ExpressedRealms.Characters.API.CharacterEndPoints.EditStatInfo;
+
+internal static class EditStatInfoForCharacter
+{
+    internal static async Task<Results<NotFound, NoContent, ValidationProblem, BadRequest<string>>> ExecuteAsync(
+        int characterId,
+        StatType statTypeId,
+        EditStatRequest request,
+        ICharacterStatRepository repository
+    )
+    {
+        var results = await repository.UpdateCharacterStat(
+            new EditStatDto()
+            {
+                CharacterId = characterId,
+                StatTypeId = statTypeId,
+                LevelTypeId = request.LevelTypeId,
+            }
+        );
+
+        if (results.HasNotFound(out var notFound))
+            return notFound;
+        if (results.HasValidationError(out var validationProblem))
+            return validationProblem;
+        if (results.HasInsufficientXP(out var insufficientXPMessage))
+            return insufficientXPMessage;
+        results.ThrowIfErrorNotHandled();
+
+        return TypedResults.NoContent();
+    }
+}

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/EditStatInfo/EditStatInfoForCharacterEndpoint.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/EditStatInfo/EditStatInfoForCharacterEndpoint.cs
@@ -10,7 +10,9 @@ namespace ExpressedRealms.Characters.API.CharacterEndPoints.EditStatInfo;
 
 internal static class EditStatInfoForCharacterEndpoint
 {
-    internal static async Task<Results<NotFound, NoContent, ValidationProblem, BadRequest<string>>> ExecuteAsync(
+    internal static async Task<
+        Results<NotFound, NoContent, ValidationProblem, BadRequest<string>>
+    > ExecuteAsync(
         int characterId,
         StatType statTypeId,
         EditStatRequest request,

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/EditStatInfo/EditStatInfoForCharacterEndpoint.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/EditStatInfo/EditStatInfoForCharacterEndpoint.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace ExpressedRealms.Characters.API.CharacterEndPoints.EditStatInfo;
 
-internal static class EditStatInfoForCharacter
+internal static class EditStatInfoForCharacterEndpoint
 {
     internal static async Task<Results<NotFound, NoContent, ValidationProblem, BadRequest<string>>> ExecuteAsync(
         int characterId,

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetDetailedStatInfo/GetDetailedStatInfoForCharacter.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetDetailedStatInfo/GetDetailedStatInfoForCharacter.cs
@@ -1,0 +1,32 @@
+using ExpressedRealms.Characters.Repository.Stats;
+using ExpressedRealms.Characters.Repository.Stats.DTOs;
+using ExpressedRealms.Characters.Repository.Stats.Enums;
+using ExpressedRealms.Server.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using SingleStatInfo = ExpressedRealms.Characters.API.StatEndPoints.Responses.SingleStatInfo;
+
+namespace ExpressedRealms.Characters.API.CharacterEndPoints.GetDetailedStatInfo;
+
+internal static class GetDetailedStatInfoForCharacter
+{
+    internal static async Task<Results<NotFound, ValidationProblem, Ok<SingleStatInfo>>> ExecuteAsync(
+        int characterId,
+        StatType statTypeId,
+        [FromServices]ICharacterStatRepository repository
+        )
+    {
+        var results = await repository.GetDetailedStatInfo(
+            new GetDetailedStatInfoDto(characterId, statTypeId)
+        );
+
+        if (results.HasNotFound(out var notFound))
+            return notFound;
+        if (results.HasValidationError(out var validationProblem))
+            return validationProblem;
+        results.ThrowIfErrorNotHandled();
+
+        return TypedResults.Ok(new SingleStatInfo(results.Value));
+    }
+}

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetDetailedStatInfo/GetDetailedStatInfoForCharacterEndpoint.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetDetailedStatInfo/GetDetailedStatInfoForCharacterEndpoint.cs
@@ -11,11 +11,13 @@ namespace ExpressedRealms.Characters.API.CharacterEndPoints.GetDetailedStatInfo;
 
 internal static class GetDetailedStatInfoForCharacterEndpoint
 {
-    internal static async Task<Results<NotFound, ValidationProblem, Ok<SingleStatInfo>>> ExecuteAsync(
+    internal static async Task<
+        Results<NotFound, ValidationProblem, Ok<SingleStatInfo>>
+    > ExecuteAsync(
         int characterId,
         StatType statTypeId,
-        [FromServices]ICharacterStatRepository repository
-        )
+        [FromServices] ICharacterStatRepository repository
+    )
     {
         var results = await repository.GetDetailedStatInfo(
             new GetDetailedStatInfoDto(characterId, statTypeId)

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetDetailedStatInfo/GetDetailedStatInfoForCharacterEndpoint.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetDetailedStatInfo/GetDetailedStatInfoForCharacterEndpoint.cs
@@ -9,7 +9,7 @@ using SingleStatInfo = ExpressedRealms.Characters.API.StatEndPoints.Responses.Si
 
 namespace ExpressedRealms.Characters.API.CharacterEndPoints.GetDetailedStatInfo;
 
-internal static class GetDetailedStatInfoForCharacter
+internal static class GetDetailedStatInfoForCharacterEndpoint
 {
     internal static async Task<Results<NotFound, ValidationProblem, Ok<SingleStatInfo>>> ExecuteAsync(
         int characterId,

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetStatsForCharacter/GetStatsForCharacterEndpoint.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetStatsForCharacter/GetStatsForCharacterEndpoint.cs
@@ -11,8 +11,8 @@ internal static class GetStatsForCharacterEndpoint
 {
     internal static async Task<Results<NotFound, Ok<List<SmallStatInfo>>>> ExecuteAsync(
         int characterId,
-        [FromServices]ICharacterStatRepository repository
-        )
+        [FromServices] ICharacterStatRepository repository
+    )
     {
         var results = await repository.GetAllStats(characterId);
 
@@ -20,8 +20,6 @@ internal static class GetStatsForCharacterEndpoint
             return notFound;
         results.ThrowIfErrorNotHandled();
 
-        return TypedResults.Ok(
-            results.Value.Select(x => new SmallStatInfo(x)).ToList()
-        );
+        return TypedResults.Ok(results.Value.Select(x => new SmallStatInfo(x)).ToList());
     }
 }

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetStatsForCharacter/GetStatsForCharacterEndpoint.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetStatsForCharacter/GetStatsForCharacterEndpoint.cs
@@ -1,0 +1,27 @@
+using ExpressedRealms.Characters.Repository.Stats;
+using ExpressedRealms.Server.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using SmallStatInfo = ExpressedRealms.Characters.API.StatEndPoints.Responses.SmallStatInfo;
+
+namespace ExpressedRealms.Characters.API.CharacterEndPoints.GetStatsForCharacter;
+
+internal static class GetStatsForCharacterEndpoint
+{
+    internal static async Task<Results<NotFound, Ok<List<SmallStatInfo>>>> ExecuteAsync(
+        int characterId,
+        [FromServices]ICharacterStatRepository repository
+        )
+    {
+        var results = await repository.GetAllStats(characterId);
+
+        if (results.HasNotFound(out var notFound))
+            return notFound;
+        results.ThrowIfErrorNotHandled();
+
+        return TypedResults.Ok(
+            results.Value.Select(x => new SmallStatInfo(x)).ToList()
+        );
+    }
+}

--- a/api/ExpressedRealms.Characters.API/StatEndPoints/Requests/EditStatRequest.cs
+++ b/api/ExpressedRealms.Characters.API/StatEndPoints/Requests/EditStatRequest.cs
@@ -1,16 +1,7 @@
-using ExpressedRealms.Characters.Repository.Stats.Enums;
-
 namespace ExpressedRealms.Characters.API.StatEndPoints.Requests;
 
 internal class EditStatRequest
 {
-    /// <example>6</example>
-    public int CharacterId { get; set; }
-
-    /// <summary>This should be the same value as in the path.  Enum Values are : 1: </summary>
-    /// <example>6</example>
-    public StatType StatTypeId { get; set; }
-
     /// <summary>This is a value between 1 and 7, to represent the different levels.</summary>
     /// <example>7</example>
     public byte LevelTypeId { get; set; }

--- a/api/ExpressedRealms.Characters.API/StatEndPoints/Responses/SingleStatInfo.cs
+++ b/api/ExpressedRealms.Characters.API/StatEndPoints/Responses/SingleStatInfo.cs
@@ -1,10 +1,11 @@
+using ExpressedRealms.Characters.API.CharacterEndPoints.StatDTOs;
 using ExpressedRealms.Characters.Repository.Stats.Enums;
 
-namespace ExpressedRealms.Characters.API.CharacterEndPoints.StatDTOs;
+namespace ExpressedRealms.Characters.API.StatEndPoints.Responses;
 
 internal record SingleStatInfo
 {
-    public SingleStatInfo(Characters.Repository.Stats.DTOs.SingleStatInfo dto)
+    public SingleStatInfo(Repository.Stats.DTOs.SingleStatInfo dto)
     {
         Id = dto.Id;
         Name = dto.Name;

--- a/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
@@ -7,6 +7,7 @@ using ExpressedRealms.DB;
 using ExpressedRealms.DB.Helpers;
 using ExpressedRealms.DB.Interceptors;
 using ExpressedRealms.DB.Models.Characters;
+using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
 using ExpressedRealms.Expressions.Repository.Expressions;
 using ExpressedRealms.Repositories.Shared;
 using ExpressedRealms.Repositories.Shared.CommonFailureTypes;
@@ -298,6 +299,18 @@ internal sealed class CharacterRepository(
 
         await context.SaveChangesAsync(cancellationToken);
 
+        for (byte i = 1; i < 7; i++)
+        {
+            context.CharacterStatMappings.Add(new CharacterStatMapping
+            {
+                CharacterId = character.Id,
+                StatLevelId = 1,
+                StatTypeId = i
+            });
+        }
+        
+        await context.SaveChangesAsync(cancellationToken);
+        
         await skillRepository.AddDefaultSkills(character.Id);
         await xpRepository.AddDefaultCharacterXpMappings(character.Id);
 

--- a/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
@@ -301,16 +301,18 @@ internal sealed class CharacterRepository(
 
         for (byte i = 1; i < 7; i++)
         {
-            context.CharacterStatMappings.Add(new CharacterStatMapping
-            {
-                CharacterId = character.Id,
-                StatLevelId = 1,
-                StatTypeId = i
-            });
+            context.CharacterStatMappings.Add(
+                new CharacterStatMapping
+                {
+                    CharacterId = character.Id,
+                    StatLevelId = 1,
+                    StatTypeId = i,
+                }
+            );
         }
-        
+
         await context.SaveChangesAsync(cancellationToken);
-        
+
         await skillRepository.AddDefaultSkills(character.Id);
         await xpRepository.AddDefaultCharacterXpMappings(character.Id);
 

--- a/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
@@ -29,56 +29,36 @@ internal sealed class CharacterStatRepository(
         var result = await detailedStatValidator.ValidateAsync(dto);
         if (!result.IsValid)
             return Result.Fail(new FluentValidationFailure(result.ToDictionary()));
-
+        
         var query = await context
             .Characters.AsNoTracking()
             .WithUserAccessAsync(userContext, dto.CharacterId);
-
-        var character = await query
+            
+        var character = await query.Select(x => x.Id).FirstOrDefaultAsync();
+        if (character == 0)
+            return Result.Fail(new NotFoundFailure("Character"));
+        
+        var stats = await context.CharacterStatMappings.AsNoTracking()
+            .Where(x => x.CharacterId == dto.CharacterId)
             .Select(x => new
             {
-                AgilityId = x.AgilityId,
-                ConstitutionId = x.ConstitutionId,
-                DexterityId = x.DexterityId,
-                StrengthId = x.StrengthId,
-                IntelligenceId = x.IntelligenceId,
-                WillpowerId = x.WillpowerId,
-                AvailableXP = StartingExperience.StartingStats
-                    - (
-                        x.AgilityStatLevel.TotalXPCost
-                        + x.ConstitutionStatLevel.TotalXPCost
-                        + x.DexterityStatLevel.TotalXPCost
-                        + x.StrengthStatLevel.TotalXPCost
-                        + x.IntelligenceStatLevel.TotalXPCost
-                        + x.WillpowerStatLevel.TotalXPCost
-                    ),
+                x.Id,
+                x.StatTypeId,
+                x.StatLevelId,
+                x.StatLevel.TotalXPCost
             })
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (character is null)
-            return Result.Fail(new NotFoundFailure("Character"));
-
-        var statLevelId = dto.StatTypeId switch
-        {
-            StatType.Agility => character.AgilityId,
-            StatType.Constitution => character.ConstitutionId,
-            StatType.Dexterity => character.DexterityId,
-            StatType.Strength => character.StrengthId,
-            StatType.Intelligence => character.IntelligenceId,
-            StatType.Willpower => character.WillpowerId,
-        };
+            .ToListAsync(cancellationToken);
+        
+        var statMapping = stats.First(x => x.StatTypeId == (byte)dto.StatTypeId);
 
         var statInfo = await context
             .StateTypes.Where(x => x.Id == (byte)dto.StatTypeId)
             .Select(x => new SingleStatInfo()
             {
-                Id = (StatType)x.Id,
                 Name = x.Name,
                 Description = x.Description,
-                StatLevel = statLevelId,
-                AvailableXP = character.AvailableXP,
                 StatLevelInfo = x
-                    .StatDescriptionMappings.Where(y => y.StatLevelId == statLevelId)
+                    .StatDescriptionMappings.Where(y => y.StatLevelId == statMapping.StatLevelId)
                     .Select(y => new StatDetails()
                     {
                         Level = y.StatLevelId,
@@ -90,6 +70,10 @@ internal sealed class CharacterStatRepository(
                     .First(),
             })
             .FirstAsync(cancellationToken);
+
+        statInfo.Id = dto.StatTypeId;
+        statInfo.StatLevel = statMapping.StatLevelId;
+        statInfo.AvailableXP = StartingExperience.StartingStats - stats.Sum(x => x.TotalXPCost);
 
         return Result.Ok(statInfo);
     }

--- a/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
@@ -148,95 +148,22 @@ internal sealed class CharacterStatRepository(
         var query = await context
             .Characters.AsNoTracking()
             .WithUserAccessAsync(userContext, characterId);
-
-        var character = await query
-            .Include(x => x.AgilityStatLevel)
-            .Include(x => x.ConstitutionStatLevel)
-            .Include(x => x.DexterityStatLevel)
-            .Include(x => x.StrengthStatLevel)
-            .Include(x => x.IntelligenceStatLevel)
-            .Include(x => x.WillpowerStatLevel)
-            .FirstOrDefaultAsync();
-
-        if (character is null)
+            
+        var character = await query.Select(x => x.Id).FirstOrDefaultAsync();
+        if (character == 0)
             return Result.Fail(new NotFoundFailure("Character"));
 
-        var statTypes = await context.StateTypes.ToListAsync(cancellationToken);
-
-        var characterStats = new List<SmallStatInfo>()
-        {
-            new()
+        return await context.CharacterStatMappings.AsNoTracking()
+            .Where(x => x.CharacterId == characterId)
+            .Select(x => new SmallStatInfo()
             {
-                StatTypeId = StatType.Agility,
-                Bonus = character.AgilityStatLevel.Bonus,
-                Level = character.AgilityStatLevel.Id,
-                ShortName = statTypes.First(x => x.Id == (byte)StatType.Agility).ShortName,
-                Name = statTypes.First(x => x.Id == (byte)StatType.Agility).Name,
-            },
-            new()
-            {
-                StatTypeId = StatType.Constitution,
-                Bonus = character.ConstitutionStatLevel.Bonus,
-                Level = character.ConstitutionStatLevel.Id,
-                ShortName = statTypes.First(x => x.Id == (byte)StatType.Constitution).ShortName,
-                Name = statTypes.First(x => x.Id == (byte)StatType.Constitution).Name,
-            },
-            new()
-            {
-                StatTypeId = StatType.Dexterity,
-                Bonus = character.DexterityStatLevel.Bonus,
-                Level = character.DexterityStatLevel.Id,
-                ShortName = statTypes.First(x => x.Id == (byte)StatType.Dexterity).ShortName,
-                Name = statTypes.First(x => x.Id == (byte)StatType.Dexterity).Name,
-            },
-            new()
-            {
-                StatTypeId = StatType.Strength,
-                Bonus = character.StrengthStatLevel.Bonus,
-                Level = character.StrengthStatLevel.Id,
-                ShortName = statTypes.First(x => x.Id == (byte)StatType.Strength).ShortName,
-                Name = statTypes.First(x => x.Id == (byte)StatType.Strength).Name,
-            },
-            new()
-            {
-                StatTypeId = StatType.Intelligence,
-                Bonus = character.IntelligenceStatLevel.Bonus,
-                Level = character.IntelligenceStatLevel.Id,
-                ShortName = statTypes.First(x => x.Id == (byte)StatType.Intelligence).ShortName,
-                Name = statTypes.First(x => x.Id == (byte)StatType.Intelligence).Name,
-            },
-            new()
-            {
-                StatTypeId = StatType.Willpower,
-                Bonus = character.WillpowerStatLevel.Bonus,
-                Level = character.WillpowerStatLevel.Id,
-                ShortName = statTypes.First(x => x.Id == (byte)StatType.Willpower).ShortName,
-                Name = statTypes.First(x => x.Id == (byte)StatType.Willpower).Name,
-            },
-        };
-
-        return Result.Ok(characterStats);
+                StatTypeId = (StatType)x.StatTypeId,
+                Bonus = x.StatLevel.Bonus,
+                Level = x.StatLevelId,
+                ShortName = x.StatType.ShortName,
+                Name = x.StatType.Name,
+            })
+            .ToListAsync(cancellationToken);
     }
 
-    public async Task<int> GetExperienceSpentOnStatsForCharacter(int characterId)
-    {
-        var character = await context
-            .Characters.Include(x => x.AgilityStatLevel)
-            .Include(x => x.ConstitutionStatLevel)
-            .Include(x => x.DexterityStatLevel)
-            .Include(x => x.StrengthStatLevel)
-            .Include(x => x.IntelligenceStatLevel)
-            .Include(x => x.WillpowerStatLevel)
-            .FirstOrDefaultAsync(
-                x => x.Id == characterId && x.Player.UserId == userContext.CurrentUserId(),
-                cancellationToken
-            );
-
-        return character!.AgilityStatLevel.TotalXPCost
-            + character.ConstitutionStatLevel.TotalXPCost
-            + character.DexterityStatLevel.TotalXPCost
-            + character.StrengthStatLevel.TotalXPCost
-            + character.IntelligenceStatLevel.TotalXPCost
-            + character.WillpowerStatLevel.TotalXPCost;
-    }
 }

--- a/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
@@ -29,26 +29,27 @@ internal sealed class CharacterStatRepository(
         var result = await detailedStatValidator.ValidateAsync(dto);
         if (!result.IsValid)
             return Result.Fail(new FluentValidationFailure(result.ToDictionary()));
-        
+
         var query = await context
             .Characters.AsNoTracking()
             .WithUserAccessAsync(userContext, dto.CharacterId);
-            
+
         var character = await query.Select(x => x.Id).FirstOrDefaultAsync();
         if (character == 0)
             return Result.Fail(new NotFoundFailure("Character"));
-        
-        var stats = await context.CharacterStatMappings.AsNoTracking()
+
+        var stats = await context
+            .CharacterStatMappings.AsNoTracking()
             .Where(x => x.CharacterId == dto.CharacterId)
             .Select(x => new
             {
                 x.Id,
                 x.StatTypeId,
                 x.StatLevelId,
-                x.StatLevel.TotalXPCost
+                x.StatLevel.TotalXPCost,
             })
             .ToListAsync(cancellationToken);
-        
+
         var statMapping = stats.First(x => x.StatTypeId == (byte)dto.StatTypeId);
 
         var statInfo = await context
@@ -87,13 +88,15 @@ internal sealed class CharacterStatRepository(
         var query = await context
             .Characters.AsNoTracking()
             .WithUserAccessAsync(userContext, dto.CharacterId);
-            
+
         var character = await query.Select(x => x.Id).FirstOrDefaultAsync();
         if (character == 0)
             return Result.Fail(new NotFoundFailure("Character"));
 
-        var mapping = await context.CharacterStatMappings
-            .Where(x => x.CharacterId == dto.CharacterId && x.StatTypeId == (byte)dto.StatTypeId)
+        var mapping = await context
+            .CharacterStatMappings.Where(x =>
+                x.CharacterId == dto.CharacterId && x.StatTypeId == (byte)dto.StatTypeId
+            )
             .FirstAsync();
 
         var xpCheck = await EditStatXpCheck(dto, mapping);
@@ -113,15 +116,11 @@ internal sealed class CharacterStatRepository(
             statMapping.CharacterId,
             XpSectionTypes.Stats
         );
-        
+
         var levels = new List<byte>() { statMapping.StatLevelId, dto.LevelTypeId };
         var types = await context
             .StatLevels.Where(x => levels.Contains(x.Id))
-            .Select(x => new
-            {
-                x.Id,
-                x.TotalXPCost
-            })
+            .Select(x => new { x.Id, x.TotalXPCost })
             .ToListAsync(cancellationToken);
 
         var oldTotalXpCost = types.First(x => x.Id == statMapping.StatLevelId).TotalXPCost;
@@ -148,12 +147,13 @@ internal sealed class CharacterStatRepository(
         var query = await context
             .Characters.AsNoTracking()
             .WithUserAccessAsync(userContext, characterId);
-            
+
         var character = await query.Select(x => x.Id).FirstOrDefaultAsync();
         if (character == 0)
             return Result.Fail(new NotFoundFailure("Character"));
 
-        return await context.CharacterStatMappings.AsNoTracking()
+        return await context
+            .CharacterStatMappings.AsNoTracking()
             .Where(x => x.CharacterId == characterId)
             .Select(x => new SmallStatInfo()
             {
@@ -166,5 +166,4 @@ internal sealed class CharacterStatRepository(
             .OrderBy(x => x.StatTypeId)
             .ToListAsync(cancellationToken);
     }
-
 }

--- a/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
@@ -163,6 +163,7 @@ internal sealed class CharacterStatRepository(
                 ShortName = x.StatType.ShortName,
                 Name = x.StatType.Name,
             })
+            .OrderBy(x => x.StatTypeId)
             .ToListAsync(cancellationToken);
     }
 

--- a/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/Stats/CharacterStatRepository.cs
@@ -2,8 +2,8 @@ using ExpressedRealms.Characters.Repository.Stats.DTOs;
 using ExpressedRealms.Characters.Repository.Stats.Enums;
 using ExpressedRealms.Characters.Repository.Xp;
 using ExpressedRealms.DB;
-using ExpressedRealms.DB.Models.Characters;
 using ExpressedRealms.DB.Models.Characters.XpTables;
+using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
 using ExpressedRealms.Repositories.Shared;
 using ExpressedRealms.Repositories.Shared.ExternalDependencies;
 using ExpressedRealms.Shared;
@@ -84,73 +84,48 @@ internal sealed class CharacterStatRepository(
         if (!result.IsValid)
             return Result.Fail(new FluentValidationFailure(result.ToDictionary()));
 
-        var query = await context.Characters.WithUserAccessAsync(userContext, dto.CharacterId);
-
-        var character = await query
-            .Include(x => x.AgilityStatLevel)
-            .Include(x => x.StrengthStatLevel)
-            .Include(x => x.ConstitutionStatLevel)
-            .Include(x => x.DexterityStatLevel)
-            .Include(x => x.IntelligenceStatLevel)
-            .Include(x => x.WillpowerStatLevel)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (character is null)
+        var query = await context
+            .Characters.AsNoTracking()
+            .WithUserAccessAsync(userContext, dto.CharacterId);
+            
+        var character = await query.Select(x => x.Id).FirstOrDefaultAsync();
+        if (character == 0)
             return Result.Fail(new NotFoundFailure("Character"));
 
-        var xpCheck = await EditStatXpCheck(dto, character);
+        var mapping = await context.CharacterStatMappings
+            .Where(x => x.CharacterId == dto.CharacterId && x.StatTypeId == (byte)dto.StatTypeId)
+            .FirstAsync();
+
+        var xpCheck = await EditStatXpCheck(dto, mapping);
         if (xpCheck.IsFailed)
             return xpCheck;
 
-        switch (dto.StatTypeId)
-        {
-            case StatType.Agility:
-                character.AgilityId = dto.LevelTypeId;
-                break;
-            case StatType.Constitution:
-                character.ConstitutionId = dto.LevelTypeId;
-                break;
-            case StatType.Dexterity:
-                character.DexterityId = dto.LevelTypeId;
-                break;
-            case StatType.Strength:
-                character.StrengthId = dto.LevelTypeId;
-                break;
-            case StatType.Intelligence:
-                character.IntelligenceId = dto.LevelTypeId;
-                break;
-            case StatType.Willpower:
-                character.WillpowerId = dto.LevelTypeId;
-                break;
-        }
+        mapping.StatLevelId = dto.LevelTypeId;
 
         await context.SaveChangesAsync(cancellationToken);
 
         return Result.Ok();
     }
 
-    private async Task<Result> EditStatXpCheck(EditStatDto dto, Character character)
+    private async Task<Result> EditStatXpCheck(EditStatDto dto, CharacterStatMapping statMapping)
     {
         var xpInfo = await xpRepository.GetAvailableXpForSection(
-            character.Id,
+            statMapping.CharacterId,
             XpSectionTypes.Stats
         );
+        
+        var levels = new List<byte>() { statMapping.StatLevelId, dto.LevelTypeId };
+        var types = await context
+            .StatLevels.Where(x => levels.Contains(x.Id))
+            .Select(x => new
+            {
+                x.Id,
+                x.TotalXPCost
+            })
+            .ToListAsync(cancellationToken);
 
-        var oldTotalXpCost = dto.StatTypeId switch
-        {
-            StatType.Agility => character.AgilityStatLevel.TotalXPCost,
-            StatType.Strength => character.StrengthStatLevel.TotalXPCost,
-            StatType.Constitution => character.ConstitutionStatLevel.TotalXPCost,
-            StatType.Dexterity => character.DexterityStatLevel.TotalXPCost,
-            StatType.Intelligence => character.IntelligenceStatLevel.TotalXPCost,
-            StatType.Willpower => character.WillpowerStatLevel.TotalXPCost,
-        };
-
-        var newTotalXpCost = await context
-            .StatLevels.Where(x => x.Id == dto.LevelTypeId)
-            .Select(x => x.TotalXPCost)
-            .FirstAsync(cancellationToken);
-
+        var oldTotalXpCost = types.First(x => x.Id == statMapping.StatLevelId).TotalXPCost;
+        var newTotalXpCost = types.First(x => x.Id == dto.LevelTypeId).TotalXPCost;
         var spentXp = xpInfo.SpentXp;
 
         spentXp -= oldTotalXpCost;

--- a/api/ExpressedRealms.Characters.Repository/Stats/ICharacterStatRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/Stats/ICharacterStatRepository.cs
@@ -8,5 +8,4 @@ public interface ICharacterStatRepository
     Task<Result<SingleStatInfo>> GetDetailedStatInfo(GetDetailedStatInfoDto dto);
     Task<Result> UpdateCharacterStat(EditStatDto dto);
     Task<Result<List<SmallStatInfo>>> GetAllStats(int characterId);
-    Task<int> GetExperienceSpentOnStatsForCharacter(int characterId);
 }

--- a/api/ExpressedRealms.DB/ExpressedRealmsDbContext.cs
+++ b/api/ExpressedRealms.DB/ExpressedRealmsDbContext.cs
@@ -7,6 +7,7 @@ using ExpressedRealms.DB.Models.Characters.AssignedXP.AssignedXpTypeModels;
 using ExpressedRealms.DB.Models.Characters.XpTables;
 using ExpressedRealms.DB.Models.Skills;
 using ExpressedRealms.DB.Models.Statistics;
+using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
 using ExpressedRealms.DB.UserProfile.PlayerDBModels.PlayerSetup;
 using ExpressedRealms.DB.UserProfile.PlayerDBModels.UserSetup;
 using Microsoft.AspNetCore.Identity;
@@ -46,6 +47,7 @@ namespace ExpressedRealms.DB
         public DbSet<PlayerAuditTrail> PlayerAuditTrails { get; set; }
         public DbSet<StatType> StateTypes { get; set; }
         public DbSet<StatLevel> StatLevels { get; set; }
+        public DbSet<CharacterStatMapping> CharacterStatMappings { get; set; }
         public DbSet<StatDescriptionMapping> StatDescriptionMappings { get; set; }
         public DbSet<CharacterSkillsMapping> CharacterSkillsMappings { get; set; }
         public DbSet<ModifierType> ModifierTypes { get; set; }

--- a/api/ExpressedRealms.DB/Migrations/20260518062518_AddCharacterStatTypeTableAndMigrateData.Designer.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260518062518_AddCharacterStatTypeTableAndMigrateData.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ExpressedRealms.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ExpressedRealms.DB.Migrations
 {
     [DbContext(typeof(ExpressedRealmsDbContext))]
-    partial class ExpressedRealmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518062518_AddCharacterStatTypeTableAndMigrateData")]
+    partial class AddCharacterStatTypeTableAndMigrateData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/ExpressedRealms.DB/Migrations/20260518062518_AddCharacterStatTypeTableAndMigrateData.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260518062518_AddCharacterStatTypeTableAndMigrateData.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System.Reflection;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
@@ -73,6 +74,18 @@ namespace ExpressedRealms.DB.Migrations
                                  (id, 6, willpower_id)
                                  ) v(character_id, stat_type_id, stat_level_id)
                                  """);
+            
+            var assembly = Assembly.GetExecutingAssembly();
+
+            using var stream = assembly.GetManifestResourceStream(
+                "ExpressedRealms.DB.Scripts.CharacterXpView.sql"
+            );
+
+            if (stream == null)
+                throw new InvalidOperationException("CharacterXpView.sql not found as embedded resource");
+
+            using var reader = new StreamReader(stream);
+            migrationBuilder.Sql(reader.ReadToEnd());
         }
 
         /// <inheritdoc />

--- a/api/ExpressedRealms.DB/Migrations/20260518062518_AddCharacterStatTypeTableAndMigrateData.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260518062518_AddCharacterStatTypeTableAndMigrateData.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ExpressedRealms.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCharacterStatTypeTableAndMigrateData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "character_stat_mapping",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    character_id = table.Column<int>(type: "integer", nullable: false),
+                    stat_type_id = table.Column<byte>(type: "smallint", nullable: false),
+                    stat_level_id = table.Column<byte>(type: "smallint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_character_stat_mapping", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_character_stat_mapping_characters_character_id",
+                        column: x => x.character_id,
+                        principalTable: "characters",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_character_stat_mapping_stat_levels_stat_level_id",
+                        column: x => x.stat_level_id,
+                        principalTable: "stat_levels",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_character_stat_mapping_state_types_stat_type_id",
+                        column: x => x.stat_type_id,
+                        principalTable: "state_types",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_character_stat_mapping_character_id",
+                table: "character_stat_mapping",
+                column: "character_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_character_stat_mapping_stat_level_id",
+                table: "character_stat_mapping",
+                column: "stat_level_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_character_stat_mapping_stat_type_id",
+                table: "character_stat_mapping",
+                column: "stat_type_id");
+
+            migrationBuilder.Sql("""
+                                 insert into public.character_stat_mapping (character_id, stat_type_id, stat_level_id)
+                                 select v.character_id, v.stat_type_id, v.stat_level_id
+                                 from public.characters
+                                 cross join lateral (
+                                 values 
+                                 (id, 1, agility_id),
+                                 (id, 2, constitution_id),
+                                 (id, 3, dexterity_id),
+                                 (id, 4, strength_id),
+                                 (id, 5, intelligence_id),
+                                 (id, 6, willpower_id)
+                                 ) v(character_id, stat_type_id, stat_level_id)
+                                 """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "character_stat_mapping");
+        }
+    }
+}

--- a/api/ExpressedRealms.DB/Migrations/20260520123859_AddDbContextForCharacterStatMappings.Designer.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260520123859_AddDbContextForCharacterStatMappings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ExpressedRealms.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ExpressedRealms.DB.Migrations
 {
     [DbContext(typeof(ExpressedRealmsDbContext))]
-    partial class ExpressedRealmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520123859_AddDbContextForCharacterStatMappings")]
+    partial class AddDbContextForCharacterStatMappings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/ExpressedRealms.DB/Migrations/20260520123859_AddDbContextForCharacterStatMappings.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260520123859_AddDbContextForCharacterStatMappings.cs
@@ -1,0 +1,146 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpressedRealms.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDbContextForCharacterStatMappings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_character_stat_mapping_characters_character_id",
+                table: "character_stat_mapping");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_character_stat_mapping_stat_levels_stat_level_id",
+                table: "character_stat_mapping");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_character_stat_mapping_state_types_stat_type_id",
+                table: "character_stat_mapping");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_character_stat_mapping",
+                table: "character_stat_mapping");
+
+            migrationBuilder.RenameTable(
+                name: "character_stat_mapping",
+                newName: "character_stat_mappings");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_character_stat_mapping_stat_type_id",
+                table: "character_stat_mappings",
+                newName: "ix_character_stat_mappings_stat_type_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_character_stat_mapping_stat_level_id",
+                table: "character_stat_mappings",
+                newName: "ix_character_stat_mappings_stat_level_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_character_stat_mapping_character_id",
+                table: "character_stat_mappings",
+                newName: "ix_character_stat_mappings_character_id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_character_stat_mappings",
+                table: "character_stat_mappings",
+                column: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_character_stat_mappings_characters_character_id",
+                table: "character_stat_mappings",
+                column: "character_id",
+                principalTable: "characters",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_character_stat_mappings_stat_levels_stat_level_id",
+                table: "character_stat_mappings",
+                column: "stat_level_id",
+                principalTable: "stat_levels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_character_stat_mappings_state_types_stat_type_id",
+                table: "character_stat_mappings",
+                column: "stat_type_id",
+                principalTable: "state_types",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_character_stat_mappings_characters_character_id",
+                table: "character_stat_mappings");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_character_stat_mappings_stat_levels_stat_level_id",
+                table: "character_stat_mappings");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_character_stat_mappings_state_types_stat_type_id",
+                table: "character_stat_mappings");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_character_stat_mappings",
+                table: "character_stat_mappings");
+
+            migrationBuilder.RenameTable(
+                name: "character_stat_mappings",
+                newName: "character_stat_mapping");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_character_stat_mappings_stat_type_id",
+                table: "character_stat_mapping",
+                newName: "ix_character_stat_mapping_stat_type_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_character_stat_mappings_stat_level_id",
+                table: "character_stat_mapping",
+                newName: "ix_character_stat_mapping_stat_level_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_character_stat_mappings_character_id",
+                table: "character_stat_mapping",
+                newName: "ix_character_stat_mapping_character_id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_character_stat_mapping",
+                table: "character_stat_mapping",
+                column: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_character_stat_mapping_characters_character_id",
+                table: "character_stat_mapping",
+                column: "character_id",
+                principalTable: "characters",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_character_stat_mapping_stat_levels_stat_level_id",
+                table: "character_stat_mapping",
+                column: "stat_level_id",
+                principalTable: "stat_levels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_character_stat_mapping_state_types_stat_type_id",
+                table: "character_stat_mapping",
+                column: "stat_type_id",
+                principalTable: "state_types",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/api/ExpressedRealms.DB/Migrations/20260520163322_RemoveOldValuesAndUpdateCopyProc.Designer.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260520163322_RemoveOldValuesAndUpdateCopyProc.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ExpressedRealms.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ExpressedRealms.DB.Migrations
 {
     [DbContext(typeof(ExpressedRealmsDbContext))]
-    partial class ExpressedRealmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520163322_RemoveOldValuesAndUpdateCopyProc")]
+    partial class RemoveOldValuesAndUpdateCopyProc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/ExpressedRealms.DB/Migrations/20260520163322_RemoveOldValuesAndUpdateCopyProc.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260520163322_RemoveOldValuesAndUpdateCopyProc.cs
@@ -1,0 +1,223 @@
+﻿using System.Reflection;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpressedRealms.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveOldValuesAndUpdateCopyProc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_characters_stat_levels_agility_id",
+                table: "characters");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_characters_stat_levels_constitution_id",
+                table: "characters");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_characters_stat_levels_dexterity_id",
+                table: "characters");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_characters_stat_levels_intelligence_id",
+                table: "characters");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_characters_stat_levels_strength_id",
+                table: "characters");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_characters_stat_levels_willpower_id",
+                table: "characters");
+
+            migrationBuilder.DropIndex(
+                name: "ix_characters_agility_id",
+                table: "characters");
+
+            migrationBuilder.DropIndex(
+                name: "ix_characters_constitution_id",
+                table: "characters");
+
+            migrationBuilder.DropIndex(
+                name: "ix_characters_dexterity_id",
+                table: "characters");
+
+            migrationBuilder.DropIndex(
+                name: "ix_characters_intelligence_id",
+                table: "characters");
+
+            migrationBuilder.DropIndex(
+                name: "ix_characters_strength_id",
+                table: "characters");
+
+            migrationBuilder.DropIndex(
+                name: "ix_characters_willpower_id",
+                table: "characters");
+
+            migrationBuilder.DropColumn(
+                name: "agility_id",
+                table: "characters");
+
+            migrationBuilder.DropColumn(
+                name: "constitution_id",
+                table: "characters");
+
+            migrationBuilder.DropColumn(
+                name: "dexterity_id",
+                table: "characters");
+
+            migrationBuilder.DropColumn(
+                name: "intelligence_id",
+                table: "characters");
+
+            migrationBuilder.DropColumn(
+                name: "strength_id",
+                table: "characters");
+
+            migrationBuilder.DropColumn(
+                name: "willpower_id",
+                table: "characters");
+            
+            var assembly = Assembly.GetExecutingAssembly();
+
+            using var stream = assembly.GetManifestResourceStream(
+                "ExpressedRealms.DB.Scripts.CopyCharacterToPlayerProc.sql"
+            );
+
+            if (stream == null)
+                throw new InvalidOperationException("CopyCharacterToPlayerProc.sql not found as embedded resource");
+
+            using var reader = new StreamReader(stream);
+            migrationBuilder.Sql(reader.ReadToEnd());
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte>(
+                name: "agility_id",
+                table: "characters",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)1);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "constitution_id",
+                table: "characters",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)1);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "dexterity_id",
+                table: "characters",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)1);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "intelligence_id",
+                table: "characters",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)1);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "strength_id",
+                table: "characters",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)1);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "willpower_id",
+                table: "characters",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)1);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_characters_agility_id",
+                table: "characters",
+                column: "agility_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_characters_constitution_id",
+                table: "characters",
+                column: "constitution_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_characters_dexterity_id",
+                table: "characters",
+                column: "dexterity_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_characters_intelligence_id",
+                table: "characters",
+                column: "intelligence_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_characters_strength_id",
+                table: "characters",
+                column: "strength_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_characters_willpower_id",
+                table: "characters",
+                column: "willpower_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_characters_stat_levels_agility_id",
+                table: "characters",
+                column: "agility_id",
+                principalTable: "stat_levels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_characters_stat_levels_constitution_id",
+                table: "characters",
+                column: "constitution_id",
+                principalTable: "stat_levels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_characters_stat_levels_dexterity_id",
+                table: "characters",
+                column: "dexterity_id",
+                principalTable: "stat_levels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_characters_stat_levels_intelligence_id",
+                table: "characters",
+                column: "intelligence_id",
+                principalTable: "stat_levels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_characters_stat_levels_strength_id",
+                table: "characters",
+                column: "strength_id",
+                principalTable: "stat_levels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_characters_stat_levels_willpower_id",
+                table: "characters",
+                column: "willpower_id",
+                principalTable: "stat_levels",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/api/ExpressedRealms.DB/Models/Characters/Character.cs
+++ b/api/ExpressedRealms.DB/Models/Characters/Character.cs
@@ -10,6 +10,7 @@ using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeMappings;
 using ExpressedRealms.DB.Models.Powers.CharacterPowerMappingSetup;
 using ExpressedRealms.DB.Models.Skills;
 using ExpressedRealms.DB.Models.Statistics;
+using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
 using ExpressedRealms.DB.UserProfile.PlayerDBModels.PlayerSetup;
 
 namespace ExpressedRealms.DB.Models.Characters;
@@ -64,4 +65,5 @@ public class Character : ISoftDelete
     public virtual List<CharacterXpMapping> CharacterXpMappings { get; set; } = null!;
     public virtual List<AssignedXpMapping> AssignedXpMappings { get; set; } = null!;
     public virtual ICollection<Contact> Contacts { get; set; } = new HashSet<Contact>();
+    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; }  = new HashSet<CharacterStatMapping>();
 }

--- a/api/ExpressedRealms.DB/Models/Characters/Character.cs
+++ b/api/ExpressedRealms.DB/Models/Characters/Character.cs
@@ -50,5 +50,6 @@ public class Character : ISoftDelete
     public virtual List<CharacterXpMapping> CharacterXpMappings { get; set; } = null!;
     public virtual List<AssignedXpMapping> AssignedXpMappings { get; set; } = null!;
     public virtual ICollection<Contact> Contacts { get; set; } = new HashSet<Contact>();
-    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; }  = new HashSet<CharacterStatMapping>();
+    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; } =
+        new HashSet<CharacterStatMapping>();
 }

--- a/api/ExpressedRealms.DB/Models/Characters/Character.cs
+++ b/api/ExpressedRealms.DB/Models/Characters/Character.cs
@@ -9,7 +9,6 @@ using ExpressedRealms.DB.Models.Expressions.ProgressionPathSetup.ProgressionPath
 using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeMappings;
 using ExpressedRealms.DB.Models.Powers.CharacterPowerMappingSetup;
 using ExpressedRealms.DB.Models.Skills;
-using ExpressedRealms.DB.Models.Statistics;
 using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
 using ExpressedRealms.DB.UserProfile.PlayerDBModels.PlayerSetup;
 
@@ -22,13 +21,6 @@ public class Character : ISoftDelete
     public string? Background { get; set; }
     public Guid PlayerId { get; set; }
     public int ExpressionId { get; set; }
-
-    public byte AgilityId { get; set; }
-    public byte ConstitutionId { get; set; }
-    public byte DexterityId { get; set; }
-    public byte StrengthId { get; set; }
-    public byte IntelligenceId { get; set; }
-    public byte WillpowerId { get; set; }
 
     public int? FactionId { get; set; }
 
@@ -50,13 +42,6 @@ public class Character : ISoftDelete
 
     public virtual Player Player { get; set; } = null!;
     public virtual Expression Expression { get; set; } = null!;
-
-    public virtual StatLevel AgilityStatLevel { get; set; } = null!;
-    public virtual StatLevel ConstitutionStatLevel { get; set; } = null!;
-    public virtual StatLevel DexterityStatLevel { get; set; } = null!;
-    public virtual StatLevel StrengthStatLevel { get; set; } = null!;
-    public virtual StatLevel IntelligenceStatLevel { get; set; } = null!;
-    public virtual StatLevel WillpowerStatLevel { get; set; } = null!;
     public virtual ExpressionSection? FactionInfo { get; set; } = null!;
     public virtual List<CharacterSkillsMapping> CharacterSkillsMappings { get; set; } = null!;
     public virtual List<CharacterKnowledgeMapping> CharacterKnowledgeMappings { get; set; } = null!;

--- a/api/ExpressedRealms.DB/Models/Characters/CharacterConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Characters/CharacterConfiguration.cs
@@ -14,13 +14,6 @@ public class CharacterConfiguration : IEntityTypeConfiguration<Character>
         builder.Property(x => x.PlayerId).IsRequired();
         builder.Property(x => x.ExpressionId).IsRequired();
 
-        builder.Property(x => x.AgilityId).IsRequired().HasDefaultValue(1);
-        builder.Property(x => x.ConstitutionId).IsRequired().HasDefaultValue(1);
-        builder.Property(x => x.DexterityId).IsRequired().HasDefaultValue(1);
-        builder.Property(x => x.StrengthId).IsRequired().HasDefaultValue(1);
-        builder.Property(x => x.IntelligenceId).IsRequired().HasDefaultValue(1);
-        builder.Property(x => x.WillpowerId).IsRequired().HasDefaultValue(1);
-
         builder.Property(x => x.FactionId);
 
         builder.Property(x => x.StatExperiencePoints).IsRequired().HasDefaultValue(72);
@@ -64,48 +57,6 @@ public class CharacterConfiguration : IEntityTypeConfiguration<Character>
             .HasOne(x => x.Expression)
             .WithMany(x => x.Characters)
             .HasForeignKey(x => x.ExpressionId)
-            .OnDelete(DeleteBehavior.Restrict)
-            .IsRequired();
-
-        builder
-            .HasOne(x => x.AgilityStatLevel)
-            .WithMany(x => x.CharacterAgility)
-            .HasForeignKey(x => x.AgilityId)
-            .OnDelete(DeleteBehavior.Restrict)
-            .IsRequired();
-
-        builder
-            .HasOne(x => x.ConstitutionStatLevel)
-            .WithMany(x => x.CharacterConstitution)
-            .HasForeignKey(x => x.ConstitutionId)
-            .OnDelete(DeleteBehavior.Restrict)
-            .IsRequired();
-
-        builder
-            .HasOne(x => x.DexterityStatLevel)
-            .WithMany(x => x.CharacterDexterity)
-            .HasForeignKey(x => x.DexterityId)
-            .OnDelete(DeleteBehavior.Restrict)
-            .IsRequired();
-
-        builder
-            .HasOne(x => x.StrengthStatLevel)
-            .WithMany(x => x.CharacterStrength)
-            .HasForeignKey(x => x.StrengthId)
-            .OnDelete(DeleteBehavior.Restrict)
-            .IsRequired();
-
-        builder
-            .HasOne(x => x.IntelligenceStatLevel)
-            .WithMany(x => x.CharacterIntelligence)
-            .HasForeignKey(x => x.IntelligenceId)
-            .OnDelete(DeleteBehavior.Restrict)
-            .IsRequired();
-
-        builder
-            .HasOne(x => x.WillpowerStatLevel)
-            .WithMany(x => x.CharacterWillpower)
-            .HasForeignKey(x => x.WillpowerId)
             .OnDelete(DeleteBehavior.Restrict)
             .IsRequired();
 

--- a/api/ExpressedRealms.DB/Models/Statistics/CharacterStatMappings/CharacterStatMapping.cs
+++ b/api/ExpressedRealms.DB/Models/Statistics/CharacterStatMappings/CharacterStatMapping.cs
@@ -1,0 +1,15 @@
+using ExpressedRealms.DB.Models.Characters;
+
+namespace ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
+
+public class CharacterStatMapping
+{
+    public int Id { get; set; }
+    public int CharacterId { get; set; }
+    public byte StatTypeId { get; set; }
+    public byte StatLevelId { get; set; }
+
+    public virtual StatLevel StatLevel { get; set; } = null!;
+    public virtual Character Character { get; set; } = null!;
+    public virtual StatType StatType { get; set; } = null!;
+}

--- a/api/ExpressedRealms.DB/Models/Statistics/CharacterStatMappings/CharacterStatMappingConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Statistics/CharacterStatMappings/CharacterStatMappingConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
+
+public class CharacterStatMappingConfiguration : IEntityTypeConfiguration<CharacterStatMapping>
+{
+    public void Configure(EntityTypeBuilder<CharacterStatMapping> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).IsRequired();
+        builder.Property(e => e.CharacterId).IsRequired();
+        builder.Property(e => e.StatTypeId).IsRequired();
+        builder.Property(e => e.StatLevelId).IsRequired();
+        
+        builder
+            .HasOne(e => e.StatType)
+            .WithMany(e => e.CharacterStatMappings)
+            .HasForeignKey(e => e.StatTypeId)
+            .OnDelete(DeleteBehavior.Restrict);
+        
+        builder
+            .HasOne(e => e.StatLevel)
+            .WithMany(e => e.CharacterStatMappings)
+            .HasForeignKey(e => e.StatLevelId)
+            .OnDelete(DeleteBehavior.Restrict);
+        
+        builder
+            .HasOne(e => e.Character)
+            .WithMany(e => e.CharacterStatMappings)
+            .HasForeignKey(e => e.CharacterId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/api/ExpressedRealms.DB/Models/Statistics/CharacterStatMappings/CharacterStatMappingConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Statistics/CharacterStatMappings/CharacterStatMappingConfiguration.cs
@@ -12,19 +12,19 @@ public class CharacterStatMappingConfiguration : IEntityTypeConfiguration<Charac
         builder.Property(e => e.CharacterId).IsRequired();
         builder.Property(e => e.StatTypeId).IsRequired();
         builder.Property(e => e.StatLevelId).IsRequired();
-        
+
         builder
             .HasOne(e => e.StatType)
             .WithMany(e => e.CharacterStatMappings)
             .HasForeignKey(e => e.StatTypeId)
             .OnDelete(DeleteBehavior.Restrict);
-        
+
         builder
             .HasOne(e => e.StatLevel)
             .WithMany(e => e.CharacterStatMappings)
             .HasForeignKey(e => e.StatLevelId)
             .OnDelete(DeleteBehavior.Restrict);
-        
+
         builder
             .HasOne(e => e.Character)
             .WithMany(e => e.CharacterStatMappings)

--- a/api/ExpressedRealms.DB/Models/Statistics/StatLevel.cs
+++ b/api/ExpressedRealms.DB/Models/Statistics/StatLevel.cs
@@ -10,5 +10,6 @@ public class StatLevel
     public int TotalXPCost { get; set; }
 
     public virtual List<StatDescriptionMapping> StatDescriptionMappings { get; set; } = null!;
-    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; }  = new HashSet<CharacterStatMapping>();
+    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; } =
+        new HashSet<CharacterStatMapping>();
 }

--- a/api/ExpressedRealms.DB/Models/Statistics/StatLevel.cs
+++ b/api/ExpressedRealms.DB/Models/Statistics/StatLevel.cs
@@ -1,4 +1,3 @@
-using ExpressedRealms.DB.Models.Characters;
 using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
 
 namespace ExpressedRealms.DB.Models.Statistics;
@@ -11,11 +10,5 @@ public class StatLevel
     public int TotalXPCost { get; set; }
 
     public virtual List<StatDescriptionMapping> StatDescriptionMappings { get; set; } = null!;
-    public virtual List<Character> CharacterAgility { get; set; } = null!;
-    public virtual List<Character> CharacterConstitution { get; set; } = null!;
-    public virtual List<Character> CharacterDexterity { get; set; } = null!;
-    public virtual List<Character> CharacterStrength { get; set; } = null!;
-    public virtual List<Character> CharacterIntelligence { get; set; } = null!;
-    public virtual List<Character> CharacterWillpower { get; set; } = null!;
     public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; }  = new HashSet<CharacterStatMapping>();
 }

--- a/api/ExpressedRealms.DB/Models/Statistics/StatLevel.cs
+++ b/api/ExpressedRealms.DB/Models/Statistics/StatLevel.cs
@@ -1,4 +1,5 @@
 using ExpressedRealms.DB.Models.Characters;
+using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
 
 namespace ExpressedRealms.DB.Models.Statistics;
 
@@ -16,4 +17,5 @@ public class StatLevel
     public virtual List<Character> CharacterStrength { get; set; } = null!;
     public virtual List<Character> CharacterIntelligence { get; set; } = null!;
     public virtual List<Character> CharacterWillpower { get; set; } = null!;
+    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; }  = new HashSet<CharacterStatMapping>();
 }

--- a/api/ExpressedRealms.DB/Models/Statistics/StatType.cs
+++ b/api/ExpressedRealms.DB/Models/Statistics/StatType.cs
@@ -10,5 +10,6 @@ public class StatType
     public string Description { get; set; }
 
     public virtual List<StatDescriptionMapping> StatDescriptionMappings { get; set; } = null!;
-    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; }  = new HashSet<CharacterStatMapping>();
+    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; } =
+        new HashSet<CharacterStatMapping>();
 }

--- a/api/ExpressedRealms.DB/Models/Statistics/StatType.cs
+++ b/api/ExpressedRealms.DB/Models/Statistics/StatType.cs
@@ -1,3 +1,5 @@
+using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
+
 namespace ExpressedRealms.DB.Models.Statistics;
 
 public class StatType
@@ -8,4 +10,5 @@ public class StatType
     public string Description { get; set; }
 
     public virtual List<StatDescriptionMapping> StatDescriptionMappings { get; set; } = null!;
+    public virtual ICollection<CharacterStatMapping> CharacterStatMappings { get; set; }  = new HashSet<CharacterStatMapping>();
 }

--- a/api/ExpressedRealms.DB/Scripts/CharacterXpView.sql
+++ b/api/ExpressedRealms.DB/Scripts/CharacterXpView.sql
@@ -1,31 +1,28 @@
 CREATE OR REPLACE VIEW public.character_xp_view
 AS
 WITH calc AS (
-    SELECT characters_1.id AS character_id,
+    SELECT character_blessing_mappings.character_id AS character_id,
            sum(blessing_levels.xp_cost) AS xp_total,
            1 AS section_type_id
-    FROM characters characters_1
-             JOIN character_blessing_mappings ON characters_1.id = character_blessing_mappings.character_id
+    FROM character_blessing_mappings
              JOIN blessings ON blessings.id = character_blessing_mappings.blessing_id
              JOIN blessing_levels ON blessing_levels.id = character_blessing_mappings.blessing_level_id
-    WHERE blessings.is_deleted = false AND character_blessing_mappings.is_deleted = false AND blessings.type::text = 'Advantage'::text
-    GROUP BY characters_1.id
+    WHERE blessings.is_deleted = false AND character_blessing_mappings.is_deleted = false AND blessings.type = 'Advantage'
+    GROUP BY character_blessing_mappings.character_id
     UNION ALL
-    SELECT characters_1.id AS character_id,
+    SELECT character_blessing_mappings.character_id AS character_id,
            sum(blessing_levels.xp_gain) AS xp_total,
            2 AS section_type_id
-    FROM characters characters_1
-             JOIN character_blessing_mappings ON characters_1.id = character_blessing_mappings.character_id
+    FROM character_blessing_mappings
              JOIN blessings ON blessings.id = character_blessing_mappings.blessing_id
              JOIN blessing_levels ON blessing_levels.id = character_blessing_mappings.blessing_level_id
-    WHERE blessings.is_deleted = false AND character_blessing_mappings.is_deleted = false AND blessings.type::text = 'Disadvantage'::text
-    GROUP BY characters_1.id
+    WHERE blessings.is_deleted = false AND character_blessing_mappings.is_deleted = false AND blessings.type = 'Disadvantage'
+    GROUP BY character_blessing_mappings.character_id
     UNION ALL
-    SELECT c.id AS character_id,
+    SELECT ckm.character_id AS character_id,
            SUM(kel.total_general_xp_cost) + (COALESCE(spec.spec_count, 0) * 2) AS xp_total,
            3 AS section_type_id
-    FROM characters c
-             JOIN character_knowledge_mappings ckm ON c.id = ckm.character_id
+    FROM character_knowledge_mappings ckm
              JOIN knowledge_education_levels kel ON ckm.knowledge_level_id = kel.id
              LEFT JOIN (
         SELECT
@@ -36,43 +33,36 @@ WITH calc AS (
         GROUP BY knowledge_mapping_id
     ) spec ON ckm.id = spec.knowledge_mapping_id
     WHERE ckm.is_deleted = false
-    GROUP BY c.id, spec.spec_count
+    GROUP BY ckm.character_id, spec.spec_count
     UNION ALL
-    SELECT characters_1.id AS character_id,
+    SELECT character_power_mappings.character_id AS character_id,
            sum(power_levels.xp) AS xp_total,
            4 AS section_type_id
-    FROM characters characters_1
-             JOIN character_power_mappings ON characters_1.id = character_power_mappings.character_id
+    FROM character_power_mappings
              JOIN power_levels ON power_levels.id = character_power_mappings.power_level_id
     WHERE character_power_mappings.is_deleted = false
-    GROUP BY characters_1.id
+    GROUP BY character_power_mappings.character_id
     UNION ALL
-    SELECT characters_1.id AS character_id,
+    SELECT character_skills_mappings.character_id AS character_id,
            sum(skill_levels.total_xp) AS total_xp,
            5 AS section_type_id
-    FROM characters characters_1
-             JOIN character_skills_mappings ON characters_1.id = character_skills_mappings.character_id
+    FROM character_skills_mappings
              JOIN skill_levels ON character_skills_mappings.skill_level_id = skill_levels.id
-    GROUP BY characters_1.id
+    GROUP BY character_skills_mappings.character_id
     UNION ALL
-    SELECT characters_1.id AS character_id,
-           agility.total_xp_cost + con.total_xp_cost + dex.total_xp_cost + stre.total_xp_cost + inti.total_xp_cost + wil.total_xp_cost AS xp_total,
+    SELECT character_stat_mapping.character_id AS character_id,
+           sum(levels.total_xp_cost) AS xp_total,
            6 AS section_type_id
-    FROM characters characters_1
-             JOIN stat_levels agility ON characters_1.agility_id = agility.id
-             JOIN stat_levels con ON characters_1.constitution_id = con.id
-             JOIN stat_levels dex ON characters_1.dexterity_id = dex.id
-             JOIN stat_levels stre ON characters_1.strength_id = stre.id
-             JOIN stat_levels inti ON characters_1.intelligence_id = inti.id
-             JOIN stat_levels wil ON characters_1.willpower_id = wil.id
+    FROM character_stat_mapping
+             JOIN stat_levels levels ON character_stat_mapping.stat_level_id = levels.id
+    GROUP BY character_stat_mapping.character_id
     UNION ALL
-    SELECT characters_1.id AS character_id,
+    SELECT contacts.character_id AS character_id,
            sum(contacts.spent_xp) AS total_xp,
            8 AS section_type_id
-    FROM characters characters_1
-             JOIN contacts ON characters_1.id = contacts.character_id
+    FROM contacts
     where contacts.is_deleted = false
-    GROUP BY characters_1.id
+    GROUP BY contacts.character_id
 )
 SELECT characters.id AS character_id,
        xp_section_types.name AS section_name,

--- a/api/ExpressedRealms.DB/Scripts/CopyCharacterToPlayerProc.sql
+++ b/api/ExpressedRealms.DB/Scripts/CopyCharacterToPlayerProc.sql
@@ -4,88 +4,84 @@ CREATE OR REPLACE PROCEDURE copy_character_to_player_proc(
     character_name          TEXT,
     INOUT new_character_id  INT
 )
-LANGUAGE plpgsql
+    LANGUAGE plpgsql
 AS $$
 BEGIN
 
-	-- insert new character record, and grab the id
-	insert into public.characters (name, player_id, expression_id, agility_id, constitution_id, dexterity_id, intelligence_id, strength_id, willpower_id, stat_experience_points, is_in_character_creation, is_primary_character, player_number, primary_progression_id, secondary_progression_id)
-	select character_name, target_player_id, expression_id, agility_id, constitution_id, dexterity_id, intelligence_id, strength_id, willpower_id, stat_experience_points, is_in_character_creation, is_primary_character, player_number, primary_progression_id, secondary_progression_id from public.characters
-	where is_deleted = false and id = source_character_id
-	RETURNING id INTO new_character_id;
-	
-	-- copy blessings over
-	insert into public.character_blessing_mappings (character_id, blessing_id, blessing_level_id, notes, is_deleted)
-	select new_character_id, blessing_id, blessing_level_id, notes, false from public.character_blessing_mappings
-	where is_deleted = false and character_id = source_character_id;
-	
-	-- copy powers over
-	insert into public.character_power_mappings (character_id, power_id, power_level_id, notes, is_deleted)
-	select new_character_id, power_id, power_level_id, notes, false from public.character_power_mappings
-	where is_deleted = false and character_id = source_character_id;
-	
-	-- copy skills over
-	insert into public.character_skills_mappings (character_id, skill_type_id, skill_level_id)
-	select new_character_id, skill_type_id, skill_level_id from public.character_skills_mappings
-	where  character_id = source_character_id;
-	
-	-- copy over xp mappings
-	insert into public.character_xp_mappings (character_id, xp_section_type_id, section_cap, spent_xp, discretion_xp, total_character_creation_xp, level_xp)
-	select new_character_id, xp_section_type_id, section_cap, spent_xp, discretion_xp, total_character_creation_xp, level_xp from public.character_xp_mappings
-	where character_id = source_character_id;
-	
-	-- copy over contacts
-	insert into public.contacts (character_id, knowledge_id, knowledge_level_id, name, notes, frequency, spent_xp, is_approved, is_deleted)
-	select new_character_id, knowledge_id, knowledge_level_id, name, notes, frequency, spent_xp, false, false from public.contacts
-	where is_deleted = false and character_id = source_character_id;
+    -- insert new character record, and grab the id
+    insert into public.characters (name, player_id, expression_id, stat_experience_points, is_in_character_creation, is_primary_character, player_number, primary_progression_id, secondary_progression_id)
+    select character_name, target_player_id, expression_id, stat_experience_points, is_in_character_creation, is_primary_character, player_number, primary_progression_id, secondary_progression_id from public.characters
+    where is_deleted = false and id = source_character_id
+    RETURNING id INTO new_character_id;
+
+    -- copy stats over
+    insert into public.character_stat_mappings (character_id, stat_type_id, stat_level_id)
+    select new_character_id, stat_type_id, stat_level_id from public.character_stat_mappings
+    where character_id = source_character_id;
+
+    -- copy blessings over
+    insert into public.character_blessing_mappings (character_id, blessing_id, blessing_level_id, notes, is_deleted)
+    select new_character_id, blessing_id, blessing_level_id, notes, false from public.character_blessing_mappings
+    where is_deleted = false and character_id = source_character_id;
+
+    -- copy powers over
+    insert into public.character_power_mappings (character_id, power_id, power_level_id, notes, is_deleted)
+    select new_character_id, power_id, power_level_id, notes, false from public.character_power_mappings
+    where is_deleted = false and character_id = source_character_id;
+
+    -- copy skills over
+    insert into public.character_skills_mappings (character_id, skill_type_id, skill_level_id)
+    select new_character_id, skill_type_id, skill_level_id from public.character_skills_mappings
+    where  character_id = source_character_id;
+
+    -- copy over xp mappings
+    insert into public.character_xp_mappings (character_id, xp_section_type_id, section_cap, spent_xp, discretion_xp, total_character_creation_xp, level_xp)
+    select new_character_id, xp_section_type_id, section_cap, spent_xp, discretion_xp, total_character_creation_xp, level_xp from public.character_xp_mappings
+    where character_id = source_character_id;
+
+    -- copy over contacts
+    insert into public.contacts (character_id, knowledge_id, knowledge_level_id, name, notes, frequency, spent_xp, is_approved, is_deleted)
+    select new_character_id, knowledge_id, knowledge_level_id, name, notes, frequency, spent_xp, false, false from public.contacts
+    where is_deleted = false and character_id = source_character_id;
 
     -- copy knowledges and knowledge specializations
-	WITH source_knowledges AS (
-	    SELECT id, knowledge_id, knowledge_level_id, notes
-	    FROM public.character_knowledge_mappings
-	    WHERE is_deleted = false
-	      AND character_id = source_character_id
-	),
-	inserted_knowledges AS (
-	    INSERT INTO public.character_knowledge_mappings 
-	        (character_id, knowledge_id, knowledge_level_id, notes, is_deleted)
-	    SELECT 
-	        new_character_id,
-	        knowledge_id,
-	        knowledge_level_id,
-	        notes,
-	        false
-	    FROM source_knowledges
-	    RETURNING id AS new_id, knowledge_id
-	),
-	mapping_ids AS (
-	    SELECT
-	        src.id      AS old_id,
-	        ins.new_id
-	    FROM inserted_knowledges ins
-	    JOIN source_knowledges src ON src.knowledge_id = ins.knowledge_id
-	)
-	INSERT INTO public.character_knowledge_specializations 
-	    (knowledge_mapping_id, name, description, notes, is_deleted)
-	SELECT
-	    m.new_id,
-	    name,
-	    description,
-	    notes,
-	    false
-	FROM public.character_knowledge_specializations
-	JOIN mapping_ids m ON m.old_id = knowledge_mapping_id
-	WHERE is_deleted = false;
+    WITH source_knowledges AS (
+        SELECT id, knowledge_id, knowledge_level_id, notes
+        FROM public.character_knowledge_mappings
+        WHERE is_deleted = false
+          AND character_id = source_character_id
+    ),
+         inserted_knowledges AS (
+             INSERT INTO public.character_knowledge_mappings
+                 (character_id, knowledge_id, knowledge_level_id, notes, is_deleted)
+                 SELECT
+                     new_character_id,
+                     knowledge_id,
+                     knowledge_level_id,
+                     notes,
+                     false
+                 FROM source_knowledges
+                 RETURNING id AS new_id, knowledge_id
+         ),
+         mapping_ids AS (
+             SELECT
+                 src.id      AS old_id,
+                 ins.new_id
+             FROM inserted_knowledges ins
+                      JOIN source_knowledges src ON src.knowledge_id = ins.knowledge_id
+         )
+    INSERT INTO public.character_knowledge_specializations
+    (knowledge_mapping_id, name, description, notes, is_deleted)
+    SELECT
+        m.new_id,
+        name,
+        description,
+        notes,
+        false
+    FROM public.character_knowledge_specializations
+             JOIN mapping_ids m ON m.old_id = knowledge_mapping_id
+    WHERE is_deleted = false;
 
-	commit;
+    commit;
 END;
 $$;
-
-
-
-
-
-
-
-
-

--- a/client/src/components/characters/wizard/stats/stores/statStore.ts
+++ b/client/src/components/characters/wizard/stats/stores/statStore.ts
@@ -39,8 +39,6 @@ export const statStore
       async updateStat(stat: Stat, characterId: number, statTypeId: number) {
         await axios.put(`/characters/${characterId}/stat/${statTypeId}`, {
           levelTypeId: stat.statLevelInfo.level,
-          statTypeId: statTypeId,
-          characterId: characterId,
         })
         await experienceInfo.updateExperience(characterId)
         await this.loadData(characterId)

--- a/k6/auth.ts
+++ b/k6/auth.ts
@@ -34,7 +34,8 @@ export function GetAuthCookieValue() {
 export function loginParams(data) {
   return {
     headers: {
-      'Cookie': `.AspNetCore.Identity.Bearer=${data.rawToken}`
+      'Cookie': `.AspNetCore.Identity.Bearer=${data.rawToken}`,
+      'Content-Type': 'application/json',
     }
   };
 }

--- a/k6/auth.ts
+++ b/k6/auth.ts
@@ -1,0 +1,40 @@
+import http from 'k6/http';
+import {check} from 'k6';
+import {secrets} from './secrets.ts';
+
+export const BASE_URL = 'https://localhost:8443';
+
+export function GetAuthCookieValue() {
+  const res = http.post(
+    `${BASE_URL}/auth/login`,
+    JSON.stringify({
+      email: secrets.email,
+      password: secrets.password,
+    }),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  check(res, { 'login ok': r => r.status === 200 });
+
+  // 1. Target the raw .NET Identity bearer cookie string
+  let authCookie = res.cookies['.AspNetCore.Identity.Bearer'];
+
+  if (!authCookie || !authCookie[0] || !authCookie[0].value) {
+    throw new Error("Authentication failed: .AspNetCore.Identity.Bearer cookie payload missing!");
+  }
+
+  // 2. Return ONLY the raw string value to cross the VU thread isolation barrier
+  return authCookie[0].value;
+}
+
+export function loginParams(data) {
+  return {
+    headers: {
+      'Cookie': `.AspNetCore.Identity.Bearer=${data.rawToken}`
+    }
+  };
+}

--- a/k6/auth.ts
+++ b/k6/auth.ts
@@ -23,7 +23,7 @@ export function GetAuthCookieValue() {
   // 1. Target the raw .NET Identity bearer cookie string
   let authCookie = res.cookies['.AspNetCore.Identity.Bearer'];
 
-  if (!authCookie || !authCookie[0] || !authCookie[0].value) {
+  if (!authCookie[0]?.value) {
     throw new Error("Authentication failed: .AspNetCore.Identity.Bearer cookie payload missing!");
   }
 

--- a/k6/detailedStatEndpoint.ts
+++ b/k6/detailedStatEndpoint.ts
@@ -1,0 +1,17 @@
+import http from 'k6/http';
+import {BASE_URL, GetAuthCookieValue, loginParams} from "./auth.ts";
+import {realisticLoadTest} from "./optionTypes.ts";
+
+export function setup() {
+  return {
+    rawToken: GetAuthCookieValue()
+  };
+}
+
+export const options = {
+  ...realisticLoadTest
+};
+
+export default function (data) {
+  http.get(`${BASE_URL}/characters/124/stat/1`, loginParams(data));
+}

--- a/k6/editStatEndpoint.ts
+++ b/k6/editStatEndpoint.ts
@@ -1,0 +1,17 @@
+import http from 'k6/http';
+import {BASE_URL, GetAuthCookieValue, loginParams} from "./auth.ts";
+import {realisticLoadTest} from "./optionTypes.ts";
+
+export function setup() {
+  return {
+    rawToken: GetAuthCookieValue()
+  };
+}
+
+export const options = {
+  ...realisticLoadTest
+};
+
+export default function (data) {
+  http.put(`${BASE_URL}/characters/124/stat/1`, JSON.stringify({ levelTypeId: 4 }), loginParams(data));
+}

--- a/k6/optionTypes.ts
+++ b/k6/optionTypes.ts
@@ -3,19 +3,46 @@
 export const stressTest = {
   insecureSkipTLSVerify: true,
   stages: [
-    { duration: '30s', target: 10 },
-    { duration: '30s', target: 25 },
-    { duration: '30s', target: 50 },
     { duration: '30s', target: 100 },
     { duration: '30s', target: 200 },
+    { duration: '30s', target: 300 },
     { duration: '30s', target: 400 },
+    { duration: '1m', target: 400 },
+    { duration: '30s', target: 200 },
     { duration: '30s', target: 0 },
   ],
 };
 
 
-export const normalSustainTest = {
+export const realisticLoadTest = {
   insecureSkipTLSVerify: true,
+  thresholds: {
+    http_req_duration: [
+      'avg<275',
+      'p(95)<500',
+    ],
+    http_reqs: [
+      'rate>50',
+    ],
+  },
+  stages: [
+    { duration: '30s', target: 30 },
+    { duration: '2m', target: 30 },
+    { duration: '30s', target: 0 },
+  ],
+};
+
+export const performanceTargetTests = {
+  insecureSkipTLSVerify: true,
+  thresholds: {
+    http_req_duration: [
+      'avg<50',
+      'p(95)<100',
+    ],
+    http_reqs: [
+      'rate>100',
+    ],
+  },
   stages: [
     { duration: '30s', target: 100 },
     { duration: '2m', target: 100 },

--- a/k6/optionTypes.ts
+++ b/k6/optionTypes.ts
@@ -36,8 +36,8 @@ export const performanceTargetTests = {
   insecureSkipTLSVerify: true,
   thresholds: {
     http_req_duration: [
-      'avg<50',
-      'p(95)<100',
+      'avg<100',
+      'p(95)<200',
     ],
     http_reqs: [
       'rate>100',

--- a/k6/optionTypes.ts
+++ b/k6/optionTypes.ts
@@ -24,6 +24,7 @@ export const realisticLoadTest = {
     http_reqs: [
       'rate>50',
     ],
+    http_req_failed: ['rate<0.01'],
   },
   stages: [
     { duration: '30s', target: 30 },
@@ -42,6 +43,7 @@ export const performanceTargetTests = {
     http_reqs: [
       'rate>100',
     ],
+    http_req_failed: ['rate<0.01'],
   },
   stages: [
     { duration: '30s', target: 100 },

--- a/k6/optionTypes.ts
+++ b/k6/optionTypes.ts
@@ -1,0 +1,24 @@
+
+
+export const stressTest = {
+  insecureSkipTLSVerify: true,
+  stages: [
+    { duration: '30s', target: 10 },
+    { duration: '30s', target: 25 },
+    { duration: '30s', target: 50 },
+    { duration: '30s', target: 100 },
+    { duration: '30s', target: 200 },
+    { duration: '30s', target: 400 },
+    { duration: '30s', target: 0 },
+  ],
+};
+
+
+export const normalSustainTest = {
+  insecureSkipTLSVerify: true,
+  stages: [
+    { duration: '30s', target: 100 },
+    { duration: '2m', target: 100 },
+    { duration: '30s', target: 0 },
+  ],
+};

--- a/k6/overallExperienceEndpoint.ts
+++ b/k6/overallExperienceEndpoint.ts
@@ -1,0 +1,17 @@
+import http from 'k6/http';
+import {BASE_URL, GetAuthCookieValue, loginParams} from "./auth.ts";
+import {stressTest} from "./optionTypes.ts";
+
+export function setup() {
+  return {
+    rawToken: GetAuthCookieValue()
+  };
+}
+
+export const options = {
+  ...stressTest
+};
+
+export default function (data) {
+  http.get(`${BASE_URL}/characters/124/overallexperience`, loginParams(data));
+}

--- a/k6/overallExperienceEndpoint.ts
+++ b/k6/overallExperienceEndpoint.ts
@@ -1,6 +1,6 @@
 import http from 'k6/http';
 import {BASE_URL, GetAuthCookieValue, loginParams} from "./auth.ts";
-import {stressTest} from "./optionTypes.ts";
+import {realisticLoadTest} from "./optionTypes.ts";
 
 export function setup() {
   return {
@@ -9,7 +9,7 @@ export function setup() {
 }
 
 export const options = {
-  ...stressTest
+  ...realisticLoadTest
 };
 
 export default function (data) {

--- a/k6/proficienciesEndpoint.ts
+++ b/k6/proficienciesEndpoint.ts
@@ -1,0 +1,19 @@
+import http from 'k6/http';
+import {BASE_URL, GetAuthCookieValue, loginParams} from "./auth.ts";
+import {stressTest} from "./optionTypes.ts";
+
+export function setup() {
+  return {
+    rawToken: GetAuthCookieValue()
+  };
+}
+
+export const options = {
+  ...stressTest
+};
+
+export default function (data) {
+
+  http.get(`${BASE_URL}/proficiencies/124`, loginParams(data));
+
+}

--- a/k6/proficienciesEndpoint.ts
+++ b/k6/proficienciesEndpoint.ts
@@ -1,6 +1,6 @@
 import http from 'k6/http';
 import {BASE_URL, GetAuthCookieValue, loginParams} from "./auth.ts";
-import {stressTest} from "./optionTypes.ts";
+import {realisticLoadTest} from "./optionTypes.ts";
 
 export function setup() {
   return {
@@ -9,7 +9,7 @@ export function setup() {
 }
 
 export const options = {
-  ...stressTest
+  ...realisticLoadTest
 };
 
 export default function (data) {

--- a/k6/statsEndpoint.ts
+++ b/k6/statsEndpoint.ts
@@ -1,6 +1,6 @@
 import http from 'k6/http';
 import {BASE_URL, GetAuthCookieValue, loginParams} from "./auth.ts";
-import {normalSustainTest} from "./optionTypes.ts";
+import {realisticLoadTest} from "./optionTypes.ts";
 
 export function setup() {
   return {
@@ -9,7 +9,7 @@ export function setup() {
 }
 
 export const options = {
-  ...normalSustainTest
+  ...realisticLoadTest
 };
 
 export default function (data) {

--- a/k6/statsEndpoint.ts
+++ b/k6/statsEndpoint.ts
@@ -1,0 +1,19 @@
+import http from 'k6/http';
+import {BASE_URL, GetAuthCookieValue, loginParams} from "./auth.ts";
+import {normalSustainTest} from "./optionTypes.ts";
+
+export function setup() {
+  return {
+    rawToken: GetAuthCookieValue()
+  };
+}
+
+export const options = {
+  ...normalSustainTest
+};
+
+export default function (data) {
+
+  http.get(`${BASE_URL}/characters/124/stats`, loginParams(data));
+
+}


### PR DESCRIPTION
 - Converted the Stat Fields on Character Table into a Mapping Table
   - This simplified a lot of codeside things, and makes it consistent with the rest of the character
 - Learned and used k6 to do performance testing on the endpoints that were effected
   - The main load stats for character endpoint is now twice as fast (locally, it can now do 400 requests a second)
 - Removed the stat fields on character, created migration script, 
 - updated create character to insert into mapping table
 - XP View was updated and optimized a bit