### PR TITLE
Fix Edit Archetype Permission Edit Button Issue + White Flash

### DIFF
--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/Responses/CharacterEditResponse.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/Responses/CharacterEditResponse.cs
@@ -17,7 +17,10 @@ internal record CharacterEditResponse
         PrimaryProgressionId = dto.PrimaryProgressionId;
         SecondaryProgressionId = dto.SecondaryProgressionId;
         IsRetired = dto.IsRetired;
+        IsArchetypeCharacter = dto.IsArchetypeCharacter;
     }
+
+    public bool IsArchetypeCharacter { get; set; }
 
     public bool IsRetired { get; set; }
 

--- a/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
@@ -191,6 +191,7 @@ internal sealed class CharacterRepository(
                 PrimaryProgressionId = x.PrimaryProgressionId,
                 SecondaryProgressionId = x.SecondaryProgressionId,
                 IsRetired = x.IsRetired,
+                IsArchetypeCharacter = x.Player.IsArchetypeAccount
             })
             .FirstOrDefaultAsync(cancellationToken);
 

--- a/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/CharacterRepository.cs
@@ -191,7 +191,7 @@ internal sealed class CharacterRepository(
                 PrimaryProgressionId = x.PrimaryProgressionId,
                 SecondaryProgressionId = x.SecondaryProgressionId,
                 IsRetired = x.IsRetired,
-                IsArchetypeCharacter = x.Player.IsArchetypeAccount
+                IsArchetypeCharacter = x.Player.IsArchetypeAccount,
             })
             .FirstOrDefaultAsync(cancellationToken);
 

--- a/api/ExpressedRealms.Characters.Repository/DTOs/GetEditCharacterDto.cs
+++ b/api/ExpressedRealms.Characters.Repository/DTOs/GetEditCharacterDto.cs
@@ -13,4 +13,5 @@ public sealed record GetEditCharacterDto
     public int? PrimaryProgressionId { get; set; }
     public int? SecondaryProgressionId { get; set; }
     public bool IsRetired { get; set; }
+    public bool IsArchetypeCharacter { get; set; }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <style>
           :root {
+              color-scheme: light dark;
               font-family: 'Inter var', sans-serif;
               --font-feature-settings: "cv02", "cv03", "cv04", "cv11";
               background-color: var(--p-background);

--- a/client/src/components/characters/character/CharacterDetailTile.vue
+++ b/client/src/components/characters/character/CharacterDetailTile.vue
@@ -21,40 +21,25 @@ const userInfo = userStore()
 
 const characterId = Number(route.params.id)
 const showFactionInfo = ref(false)
-const isOwner = ref(false)
 
 onBeforeMount(async () => {
   await characterInfo.getCharacterDetails(characterId)
-    .then(() => {
-      name.value = characterInfo.name
-      expression.value = characterInfo.expression
-      faction.value = characterInfo.faction
-      isPrimaryCharacter.value = characterInfo.isPrimaryCharacter
-      isOwner.value = characterInfo.isOwner
-      isInCharacterGeneration.value = characterInfo.isInCharacterCreation
-      isRetired.value = characterInfo.isRetired
-    })
   showFactionInfo.value = await userInfo.hasFeatureFlag(FeatureFlags.ShowFactionDropdown)
   await experienceInfo.getExperience(characterId)
 })
-
-const name = ref('')
-const faction = ref('')
-const expression = ref('')
-const isPrimaryCharacter = ref(false)
-const isInCharacterGeneration = ref(false)
-const isRetired = ref(false)
 
 const redirectToEdit = () => {
   router.push({ name: 'characterWizard', params: { id: characterId } })
 }
 
 async function downloadCharacterBooklet() {
-  await downloadFile(`/characters/${Number(characterId)}/getcrb`, `${name.value} - ${userInfo.name} - CRB.pdf`)
+  await downloadFile(`/characters/${Number(characterId)}/getcrb`, `${characterInfo.name} - CRB.pdf`)
 }
 
 const canDownloadCrb = computed(() => permissionCheck.CharacterManagement.DownloadAllCrbs
-  || (isPrimaryCharacter.value && permissionCheck.CharacterManagement.ViewCharacterSheet))
+  || (characterInfo.isPrimaryCharacter && permissionCheck.CharacterManagement.ViewCharacterSheet))
+
+const canEditCharacterSheet = computed(() => (characterInfo.isOwner && !characterInfo.isRetired) || (characterInfo.isArchetypeCharacter && permissionCheck.Archetypes.Edit))
 </script>
 
 <template>
@@ -65,34 +50,34 @@ const canDownloadCrb = computed(() => permissionCheck.CharacterManagement.Downlo
           <div class="d-flex flex-column flex-md-row gap-3">
             <div>
               <h1 class="mt-0 pt-0 pb-0 mb-0">
-                {{ name }}
+                {{ characterInfo.name }}
               </h1>
             </div>
             <div class="d-flex flex-row align-content-between gap-3">
               <div class="d-md-none d-block flex-fill">
-                <div v-if="!experienceInfo.isLoading && !isInCharacterGeneration">
-                  <em><span>XL: {{ experienceInfo.characterLevel }}</span> - {{ expression }}</em>
+                <div v-if="!experienceInfo.isLoading && !characterInfo.isInCharacterCreation">
+                  <em><span>XL: {{ experienceInfo.characterLevel }}</span> - {{ characterInfo.expression }}</em>
                 </div>
               </div>
               <div class="align-content-center">
-                <div><Tag v-if="isPrimaryCharacter" value="Primary" severity="info" /></div>
-                <div><Tag v-if="isRetired" value="Retired" severity="warn" /></div>
+                <div><Tag v-if="characterInfo.isPrimaryCharacter" value="Primary" severity="info" /></div>
+                <div><Tag v-if="characterInfo.isRetired" value="Retired" severity="warn" /></div>
               </div>
             </div>
           </div>
-          <div v-if="!experienceInfo.isLoading && !isInCharacterGeneration" class="d-md-block d-none">
-            <em><span>XL: {{ experienceInfo.characterLevel }}</span> - {{ expression }}</em>
+          <div v-if="!experienceInfo.isLoading && !characterInfo.isInCharacterCreation" class="d-md-block d-none">
+            <em><span>XL: {{ experienceInfo.characterLevel }}</span> - {{ characterInfo.expression }}</em>
           </div>
-          <div v-if="!experienceInfo.isLoading && isInCharacterGeneration">
-            <em>In Character Creation - {{ expression }}</em>
+          <div v-if="!experienceInfo.isLoading && characterInfo.isInCharacterCreation">
+            <em>In Character Creation - {{ characterInfo.expression }}</em>
           </div>
           <div v-if="showFactionInfo">
-            <em>{{ faction?.name ?? 'No Faction' }}</em>
+            <em>{{ characterInfo.faction?.name ?? 'No Faction' }}</em>
           </div>
         </div>
         <div class="mt-3 text-right">
           <Button v-if="canDownloadCrb" label="Download CRB" class="mr-3" @click="downloadCharacterBooklet()" />
-          <Button v-if="isOwner && !isRetired || permissionCheck.Archetypes.Edit" label="Edit" @click="redirectToEdit" />
+          <Button v-if="canEditCharacterSheet" label="Edit" @click="redirectToEdit" />
         </div>
       </div>
     </template>

--- a/client/src/components/characters/character/stores/characterStore.ts
+++ b/client/src/components/characters/character/stores/characterStore.ts
@@ -17,6 +17,7 @@ export const characterStore
         isInCharacterCreation: false as boolean,
         primaryProgressionId: 0 as number,
         secondaryProgressionId: 0 as number,
+        isArchetypeCharacter: false as boolean,
         isOwner: false as boolean,
         factions: [] as any[],
         faction: {} as any,
@@ -38,6 +39,7 @@ export const characterStore
             this.primaryProgressionId = response.data.primaryProgressionId
             this.secondaryProgressionId = response.data.secondaryProgressionId
             this.isRetired = response.data.isRetired
+            this.isArchetypeCharacter = response.data.isArchetypeCharacter
 
             if (await userInfo.hasFeatureFlag(FeatureFlags.ShowFactionDropdown)) {
               await axios.get(`/characters/${characterId}/factionOptions`)


### PR DESCRIPTION
 - Archetypes were seeing the edit button on all character sheets, even ones they didn't have access to
 - In Firefox, fixed the white flash that happens with a dark theme