### PR TITLE
Migrate to Power Path Power Mapping Table

### DIFF
--- a/api/ExpressedRealms.Admin.Repository/ActivityLogs/ActivityLogRepository.cs
+++ b/api/ExpressedRealms.Admin.Repository/ActivityLogs/ActivityLogRepository.cs
@@ -170,11 +170,11 @@ public class ActivityLogRepository(ExpressedRealmsDbContext context) : IActivity
         var powerLogs = await context
             .PowerAuditTrails.AsNoTracking()
             .IgnoreQueryFilters()
-            .Where(x => x.ActorUserId == userId)
+            .Where(x => x.ActorUserId == userId && x.Power.PowerPathPowerMapping != null)
             .Select(x => new Log()
             {
                 Location =
-                    $"{x.PowerPath.Expression.ExpressionType.Name} \"{x.Power.PowerPath.Expression.Name}\" > Power Path \"{x.PowerPath.Name}\" > Power \"{x.Power.Name}\"",
+                    $"{x.Power.PowerPathPowerMapping!.PowerPath.Expression.ExpressionType.Name} \"{x.Power.PowerPathPowerMapping.PowerPath.Expression.Name}\" > Power Path \"{x.Power.PowerPathPowerMapping.PowerPath.Name}\" > Power \"{x.Power.Name}\"",
                 TimeStamp = x.Timestamp,
                 Action = x.Action,
                 ChangedProperties = x.ChangedProperties,

--- a/api/ExpressedRealms.DB/Migrations/20260608063107_AddPowerPathPowerMappingTable.Designer.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260608063107_AddPowerPathPowerMappingTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ExpressedRealms.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ExpressedRealms.DB.Migrations
 {
     [DbContext(typeof(ExpressedRealmsDbContext))]
-    partial class ExpressedRealmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608063107_AddPowerPathPowerMappingTable")]
+    partial class AddPowerPathPowerMappingTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/ExpressedRealms.DB/Migrations/20260608063107_AddPowerPathPowerMappingTable.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260608063107_AddPowerPathPowerMappingTable.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ExpressedRealms.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPowerPathPowerMappingTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "power_path_power_mappings",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    power_path_id = table.Column<int>(type: "integer", nullable: false),
+                    power_id = table.Column<int>(type: "integer", nullable: false),
+                    order_index = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_power_path_power_mappings", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_power_path_power_mappings_power_paths_power_path_id",
+                        column: x => x.power_path_id,
+                        principalTable: "power_paths",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_power_path_power_mappings_powers_power_id",
+                        column: x => x.power_id,
+                        principalTable: "powers",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_power_path_power_mappings_power_id",
+                table: "power_path_power_mappings",
+                column: "power_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_power_path_power_mappings_power_path_id",
+                table: "power_path_power_mappings",
+                column: "power_path_id");
+            
+            
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "power_path_power_mappings");
+        }
+    }
+}

--- a/api/ExpressedRealms.DB/Migrations/20260608063107_AddPowerPathPowerMappingTable.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260608063107_AddPowerPathPowerMappingTable.cs
@@ -47,8 +47,11 @@ namespace ExpressedRealms.DB.Migrations
                 name: "ix_power_path_power_mappings_power_path_id",
                 table: "power_path_power_mappings",
                 column: "power_path_id");
-            
-            
+
+            migrationBuilder.Sql("""
+                                 insert into public.power_path_power_mappings (power_id, power_path_id, order_index)
+                                 select id, power_path_id, order_index FROM public.powers
+                                 """);
         }
 
         /// <inheritdoc />

--- a/api/ExpressedRealms.DB/Migrations/20260608074308_RemovePathIdAndOrderIndexOnPowers.Designer.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260608074308_RemovePathIdAndOrderIndexOnPowers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ExpressedRealms.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ExpressedRealms.DB.Migrations
 {
     [DbContext(typeof(ExpressedRealmsDbContext))]
-    partial class ExpressedRealmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608074308_RemovePathIdAndOrderIndexOnPowers")]
+    partial class RemovePathIdAndOrderIndexOnPowers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/ExpressedRealms.DB/Migrations/20260608074308_RemovePathIdAndOrderIndexOnPowers.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260608074308_RemovePathIdAndOrderIndexOnPowers.cs
@@ -1,0 +1,136 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpressedRealms.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemovePathIdAndOrderIndexOnPowers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_power_audit_trails_power_paths_power_path_id",
+                table: "power_audit_trails");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_power_path_power_mappings_powers_power_id",
+                table: "power_path_power_mappings");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_powers_power_paths_power_path_id",
+                table: "powers");
+
+            migrationBuilder.DropIndex(
+                name: "ix_powers_power_path_id",
+                table: "powers");
+
+            migrationBuilder.DropIndex(
+                name: "ix_power_path_power_mappings_power_id",
+                table: "power_path_power_mappings");
+
+            migrationBuilder.DropIndex(
+                name: "ix_power_audit_trails_power_path_id",
+                table: "power_audit_trails");
+
+            migrationBuilder.DropColumn(
+                name: "order_index",
+                table: "powers");
+
+            migrationBuilder.DropColumn(
+                name: "power_path_id",
+                table: "powers");
+
+            migrationBuilder.DropColumn(
+                name: "power_path_id",
+                table: "power_audit_trails");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_power_path_power_mappings_power_id",
+                table: "power_path_power_mappings",
+                column: "power_id",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_power_path_power_mappings_powers_power_id",
+                table: "power_path_power_mappings",
+                column: "power_id",
+                principalTable: "powers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_power_path_power_mappings_powers_power_id",
+                table: "power_path_power_mappings");
+
+            migrationBuilder.DropIndex(
+                name: "ix_power_path_power_mappings_power_id",
+                table: "power_path_power_mappings");
+
+            migrationBuilder.AddColumn<int>(
+                name: "order_index",
+                table: "powers",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "power_path_id",
+                table: "powers",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "power_path_id",
+                table: "power_audit_trails",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_powers_power_path_id",
+                table: "powers",
+                column: "power_path_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_power_path_power_mappings_power_id",
+                table: "power_path_power_mappings",
+                column: "power_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_power_audit_trails_power_path_id",
+                table: "power_audit_trails",
+                column: "power_path_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_power_audit_trails_power_paths_power_path_id",
+                table: "power_audit_trails",
+                column: "power_path_id",
+                principalTable: "power_paths",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_power_path_power_mappings_powers_power_id",
+                table: "power_path_power_mappings",
+                column: "power_id",
+                principalTable: "powers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_powers_power_paths_power_path_id",
+                table: "powers",
+                column: "power_path_id",
+                principalTable: "power_paths",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/api/ExpressedRealms.DB/Models/Powers/Configuration/PowersDbContextPartial.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/Configuration/PowersDbContextPartial.cs
@@ -1,5 +1,6 @@
 using ExpressedRealms.DB.Models.Powers;
 using ExpressedRealms.DB.Models.Powers.CharacterPowerMappingSetup;
+using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPathSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPrerequisitePowerSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPrerequisiteSetup;
@@ -24,4 +25,5 @@ public partial class ExpressedRealmsDbContext
     public DbSet<PowerAuditTrail> PowerAuditTrails { get; set; }
     public DbSet<PowerPrerequisitePower> PowerPrerequisitePowers { get; set; }
     public DbSet<CharacterPowerMapping> CharacterPowerMappings { get; set; }
+    public DbSet<PowerPathPowerMapping> PowerPathPowerMappings { get; set; }
 }

--- a/api/ExpressedRealms.DB/Models/Powers/PowerPathPowerMappingSetup/PowerPathPowerMapping.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerPathPowerMappingSetup/PowerPathPowerMapping.cs
@@ -1,0 +1,14 @@
+using ExpressedRealms.DB.Models.Powers.PowerPathSetup;
+
+namespace ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
+
+public class PowerPathPowerMapping
+{
+    public int Id { get; set; }
+    public int PowerPathId { get; set; }
+    public int PowerId { get; set; }
+    public int OrderIndex { get; set; }
+
+    public virtual Power Power { get; set; } = null!;
+    public virtual PowerPath PowerPath { get; set; } = null!;
+}

--- a/api/ExpressedRealms.DB/Models/Powers/PowerPathPowerMappingSetup/PowerPathPowerMappingConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerPathPowerMappingSetup/PowerPathPowerMappingConfiguration.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
+
+public class PowerPathPowerMappingConfiguration : IEntityTypeConfiguration<PowerPathPowerMapping>
+{
+    public void Configure(EntityTypeBuilder<PowerPathPowerMapping> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).IsRequired();
+        builder.Property(e => e.PowerPathId).IsRequired();
+        builder.Property(e => e.PowerId).IsRequired();
+        builder.Property(e => e.OrderIndex).IsRequired();
+
+        builder
+            .HasOne(e => e.Power)
+            .WithMany(e => e.PowerPathPowerMappings)
+            .HasForeignKey(e => e.PowerId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder
+            .HasOne(e => e.PowerPath)
+            .WithMany(e => e.PowerPathPowerMappings)
+            .HasForeignKey(e => e.PowerPathId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/api/ExpressedRealms.DB/Models/Powers/PowerPathPowerMappingSetup/PowerPathPowerMappingConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerPathPowerMappingSetup/PowerPathPowerMappingConfiguration.cs
@@ -14,12 +14,6 @@ public class PowerPathPowerMappingConfiguration : IEntityTypeConfiguration<Power
         builder.Property(e => e.OrderIndex).IsRequired();
 
         builder
-            .HasOne(e => e.Power)
-            .WithMany(e => e.PowerPathPowerMappings)
-            .HasForeignKey(e => e.PowerId)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        builder
             .HasOne(e => e.PowerPath)
             .WithMany(e => e.PowerPathPowerMappings)
             .HasForeignKey(e => e.PowerPathId)

--- a/api/ExpressedRealms.DB/Models/Powers/PowerPathSetup/PowerPath.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerPathSetup/PowerPath.cs
@@ -1,6 +1,7 @@
 using Audit.EntityFramework;
 using ExpressedRealms.DB.Interceptors;
 using ExpressedRealms.DB.Models.Expressions.ExpressionSetup;
+using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 using ExpressedRealms.DB.Models.Powers.PowerSetup.Audit;
 
 namespace ExpressedRealms.DB.Models.Powers.PowerPathSetup;
@@ -22,4 +23,6 @@ public class PowerPath : ISoftDelete
     public virtual List<Power> Powers { get; set; } = null!;
     public virtual List<PowerPathAuditTrail> PowerPathAudits { get; set; } = null!;
     public virtual List<PowerAuditTrail> PowerAuditTrails { get; set; } = null!;
+    public virtual ICollection<PowerPathPowerMapping> PowerPathPowerMappings { get; set; } =
+        new List<PowerPathPowerMapping>();
 }

--- a/api/ExpressedRealms.DB/Models/Powers/PowerPathSetup/PowerPath.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerPathSetup/PowerPath.cs
@@ -2,7 +2,6 @@ using Audit.EntityFramework;
 using ExpressedRealms.DB.Interceptors;
 using ExpressedRealms.DB.Models.Expressions.ExpressionSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
-using ExpressedRealms.DB.Models.Powers.PowerSetup.Audit;
 
 namespace ExpressedRealms.DB.Models.Powers.PowerPathSetup;
 
@@ -20,9 +19,7 @@ public class PowerPath : ISoftDelete
     public bool IsDeleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
 
-    public virtual List<Power> Powers { get; set; } = null!;
     public virtual List<PowerPathAuditTrail> PowerPathAudits { get; set; } = null!;
-    public virtual List<PowerAuditTrail> PowerAuditTrails { get; set; } = null!;
     public virtual ICollection<PowerPathPowerMapping> PowerPathPowerMappings { get; set; } =
         new List<PowerPathPowerMapping>();
 }

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Audit/PowerAuditTrail.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Audit/PowerAuditTrail.cs
@@ -1,12 +1,10 @@
 using ExpressedRealms.DB.Interceptors;
-using ExpressedRealms.DB.Models.Powers.PowerPathSetup;
 using ExpressedRealms.DB.UserProfile.PlayerDBModels.UserSetup;
 
 namespace ExpressedRealms.DB.Models.Powers.PowerSetup.Audit;
 
 public class PowerAuditTrail : IAuditTable
 {
-    public int PowerPathId { get; set; }
     public int PowerId { get; set; }
 
     public int Id { get; set; }
@@ -15,7 +13,6 @@ public class PowerAuditTrail : IAuditTable
     public string ActorUserId { get; set; }
     public string ChangedProperties { get; set; }
 
-    public virtual PowerPath PowerPath { get; set; }
     public virtual Power Power { get; set; }
     public virtual User ActorUser { get; set; }
 }

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Audit/PowerAuditTrailConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Audit/PowerAuditTrailConfiguration.cs
@@ -11,7 +11,6 @@ internal class PowerAuditTrailConfiguration : IEntityTypeConfiguration<PowerAudi
         builder.Property(e => e.Id).IsRequired().ValueGeneratedOnAdd();
 
         builder.Property(e => e.PowerId).IsRequired();
-        builder.Property(e => e.PowerPathId).IsRequired();
 
         builder.Property(e => e.Action).IsRequired();
         builder.Property(e => e.ActorUserId).IsRequired();
@@ -22,13 +21,6 @@ internal class PowerAuditTrailConfiguration : IEntityTypeConfiguration<PowerAudi
             .HasOne(x => x.Power)
             .WithMany(x => x.PowerAuditTrails)
             .HasForeignKey(x => x.PowerId)
-            .OnDelete(DeleteBehavior.Restrict)
-            .IsRequired();
-
-        builder
-            .HasOne(x => x.PowerPath)
-            .WithMany(x => x.PowerAuditTrails)
-            .HasForeignKey(x => x.PowerPathId)
             .OnDelete(DeleteBehavior.Restrict)
             .IsRequired();
 

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Audit/PowerAuditTrailExtensions.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Audit/PowerAuditTrailExtensions.cs
@@ -14,7 +14,6 @@ internal static class PowerAuditTrailExtensions
             switch (changedRecord.ColumnName)
             {
                 case "id":
-                case "power_path_id":
                     continue;
 
                 case "name":
@@ -61,10 +60,6 @@ internal static class PowerAuditTrailExtensions
                     changedRecord.FriendlyName = "Cost";
                     break;
 
-                case "order_index":
-                    changedRecord.FriendlyName = "Sort Order";
-                    break;
-
                 case "stat_modifier_group_id":
                     changedRecord.Message = "Added a stat modifier group";
                     break;
@@ -85,7 +80,6 @@ internal static class PowerAuditTrailExtensions
             (table, audit) =>
             {
                 audit.PowerId = table.Id;
-                audit.PowerPathId = table.PowerPathId;
                 return true;
             }
         );

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
@@ -43,7 +43,7 @@ public class Power : ISoftDelete
     public virtual List<PowerCategoryMapping> CategoryMappings { get; set; } = null!;
 
     public virtual PowerPathPowerMapping? PowerPathPowerMapping { get; set; }
-    
+
     public virtual PowerPrerequisite? Prerequisite { get; set; } = null!;
     public virtual List<PowerPrerequisitePower> PrerequisitePowers { get; set; } = null!;
     public virtual List<PowerAuditTrail> PowerAuditTrails { get; set; } = null!;

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
@@ -3,7 +3,6 @@ using ExpressedRealms.DB.Interceptors;
 using ExpressedRealms.DB.Models.ModifierSystem.StatModifierGroups;
 using ExpressedRealms.DB.Models.Powers.CharacterPowerMappingSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
-using ExpressedRealms.DB.Models.Powers.PowerPathSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPrerequisitePowerSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPrerequisiteSetup;
 using ExpressedRealms.DB.Models.Powers.PowerSetup.Audit;
@@ -29,9 +28,6 @@ public class Power : ISoftDelete
     public byte DurationId { get; set; }
     public virtual PowerDuration PowerDuration { get; set; } = null!;
 
-    public int PowerPathId { get; set; }
-    public virtual PowerPath PowerPath { get; set; } = null!;
-
     public int? StatModifierGroupId { get; set; }
     public StatModifierGroup? StatModifierGroup { get; set; }
 
@@ -40,14 +36,13 @@ public class Power : ISoftDelete
     public string? Limitation { get; set; }
     public string? OtherFields { get; set; }
     public string? Cost { get; set; }
-    public int OrderIndex { get; set; }
 
     public bool IsDeleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
 
     public virtual List<PowerCategoryMapping> CategoryMappings { get; set; } = null!;
 
-    public virtual PowerPathPowerMapping PowerPathPowerMapping { get; set; } = null!;
+    public virtual PowerPathPowerMapping? PowerPathPowerMapping { get; set; }
     
     public virtual PowerPrerequisite? Prerequisite { get; set; } = null!;
     public virtual List<PowerPrerequisitePower> PrerequisitePowers { get; set; } = null!;

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
@@ -47,8 +47,7 @@ public class Power : ISoftDelete
 
     public virtual List<PowerCategoryMapping> CategoryMappings { get; set; } = null!;
 
-    public virtual ICollection<PowerPathPowerMapping> PowerPathPowerMappings { get; set; } =
-        new List<PowerPathPowerMapping>();
+    public virtual PowerPathPowerMapping PowerPathPowerMapping { get; set; } = null!;
     
     public virtual PowerPrerequisite? Prerequisite { get; set; } = null!;
     public virtual List<PowerPrerequisitePower> PrerequisitePowers { get; set; } = null!;

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
@@ -2,6 +2,7 @@ using Audit.EntityFramework;
 using ExpressedRealms.DB.Interceptors;
 using ExpressedRealms.DB.Models.ModifierSystem.StatModifierGroups;
 using ExpressedRealms.DB.Models.Powers.CharacterPowerMappingSetup;
+using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPathSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPrerequisitePowerSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPrerequisiteSetup;
@@ -46,6 +47,9 @@ public class Power : ISoftDelete
 
     public virtual List<PowerCategoryMapping> CategoryMappings { get; set; } = null!;
 
+    public virtual ICollection<PowerPathPowerMapping> PowerPathPowerMappings { get; set; } =
+        new List<PowerPathPowerMapping>();
+    
     public virtual PowerPrerequisite? Prerequisite { get; set; } = null!;
     public virtual List<PowerPrerequisitePower> PrerequisitePowers { get; set; } = null!;
     public virtual List<PowerAuditTrail> PowerAuditTrails { get; set; } = null!;

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/PowerConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/PowerConfiguration.cs
@@ -45,6 +45,5 @@ public class PowerConfiguration : IEntityTypeConfiguration<Power>
             .WithMany(e => e.Powers)
             .HasForeignKey(e => e.DurationId)
             .OnDelete(DeleteBehavior.Restrict);
-
     }
 }

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/PowerConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/PowerConfiguration.cs
@@ -12,9 +12,7 @@ public class PowerConfiguration : IEntityTypeConfiguration<Power>
         builder.Property(e => e.Name).HasMaxLength(250).IsRequired();
         builder.Property(e => e.Description).IsRequired();
         builder.Property(e => e.LevelId).IsRequired();
-        builder.Property(e => e.PowerPathId).IsRequired();
         builder.Property(e => e.Cost);
-        builder.Property(e => e.OrderIndex).IsRequired();
         builder.Property(e => e.StatModifierGroupId);
         builder
             .HasOne(e => e.StatModifierGroup)
@@ -48,10 +46,5 @@ public class PowerConfiguration : IEntityTypeConfiguration<Power>
             .HasForeignKey(e => e.DurationId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        builder
-            .HasOne(e => e.PowerPath)
-            .WithMany(e => e.Powers)
-            .HasForeignKey(e => e.PowerPathId)
-            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
@@ -89,7 +89,7 @@ internal sealed class CharacterPowerRepository(
 
         // Grab all powers plus prerequisite data
         var allPowers = await context
-            .Powers.Where(x => x.PowerPath.ExpressionId == expressionId)
+            .Powers.Where(x => x.PowerPathPowerMapping != null && x.PowerPathPowerMapping.PowerPath.ExpressionId == expressionId)
             .Select(x => new
             {
                 PowerId = x.Id,

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
@@ -30,8 +30,8 @@ internal sealed class CharacterPowerRepository(
     {
         return await context
             .CharacterPowerMappings.Where(x => x.CharacterId == characterId)
-            .OrderBy(x => x.Power.PowerPathPowerMapping.PowerPath.OrderIndex)
-            .ThenBy(x => x.Power.PowerPathPowerMapping.OrderIndex)
+            .OrderBy(x => x.Power.PowerPathPowerMapping!.PowerPath.OrderIndex)
+            .ThenBy(x => x.Power.PowerPathPowerMapping!.OrderIndex)
             .Select(x => new CharacterCrbInfo()
             {
                 Name = x.Power.Name,

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
@@ -30,8 +30,8 @@ internal sealed class CharacterPowerRepository(
     {
         return await context
             .CharacterPowerMappings.Where(x => x.CharacterId == characterId)
-            .OrderBy(x => x.Power.PowerPath.OrderIndex)
-            .ThenBy(x => x.Power.OrderIndex)
+            .OrderBy(x => x.Power.PowerPathPowerMapping.PowerPath.OrderIndex)
+            .ThenBy(x => x.Power.PowerPathPowerMapping.OrderIndex)
             .Select(x => new CharacterCrbInfo()
             {
                 Name = x.Power.Name,

--- a/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/CharacterPower/CharacterPowerRepository.cs
@@ -89,7 +89,10 @@ internal sealed class CharacterPowerRepository(
 
         // Grab all powers plus prerequisite data
         var allPowers = await context
-            .Powers.Where(x => x.PowerPathPowerMapping != null && x.PowerPathPowerMapping.PowerPath.ExpressionId == expressionId)
+            .Powers.Where(x =>
+                x.PowerPathPowerMapping != null
+                && x.PowerPathPowerMapping.PowerPath.ExpressionId == expressionId
+            )
             .Select(x => new
             {
                 PowerId = x.Id,

--- a/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
@@ -44,7 +44,7 @@ internal sealed class PowerPathRepository(
     public async Task<Result<List<PowerPathToc>>> GetPowerPathAndPowers(List<int> powerIds)
     {
         var items = await context
-            .PowerPaths.Where(x => x.Powers.Any(y => powerIds.Contains(y.Id)))
+            .PowerPaths.Where(x => x.PowerPathPowerMappings.Any(y => powerIds.Contains(y.PowerId)))
             .OrderBy(x => x.OrderIndex)
             .Select(x => new PowerPathToc()
             {

--- a/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
@@ -31,11 +31,10 @@ internal sealed class PowerPathRepository(
                 Id = x.Id,
                 Name = x.Name,
                 Description = x.Description,
-                Powers = x
-                    .Powers.AsQueryable()
-                    .OrderBy(x => x.OrderIndex)
-                    .Select(PowerInformation.Selector)
-                    .ToList(),
+                Powers = x.PowerPathPowerMappings.AsQueryable()
+                    .OrderBy(y => y.OrderIndex)
+                    .Select(PowerInformation.Selector())
+                    .ToList()
             })
             .ToListAsync(cancellationToken);
 
@@ -52,12 +51,11 @@ internal sealed class PowerPathRepository(
                 Id = x.Id,
                 Name = x.Name,
                 Description = x.Description,
-                Powers = x
-                    .Powers.Where(x => powerIds.Contains(x.Id))
-                    .OrderBy(x => x.OrderIndex)
-                    .AsQueryable()
-                    .Select(PowerInformation.Selector)
-                    .ToList(),
+                Powers = x.PowerPathPowerMappings.AsQueryable()
+                    .Where(y => powerIds.Contains(y.PowerId))
+                    .OrderBy(y => y.OrderIndex)
+                    .Select(PowerInformation.Selector())
+                    .ToList()
             })
             .ToListAsync(cancellationToken);
 

--- a/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
@@ -31,10 +31,11 @@ internal sealed class PowerPathRepository(
                 Id = x.Id,
                 Name = x.Name,
                 Description = x.Description,
-                Powers = x.PowerPathPowerMappings.AsQueryable()
+                Powers = x
+                    .PowerPathPowerMappings.AsQueryable()
                     .OrderBy(y => y.OrderIndex)
                     .Select(PowerInformation.Selector())
-                    .ToList()
+                    .ToList(),
             })
             .ToListAsync(cancellationToken);
 
@@ -51,11 +52,12 @@ internal sealed class PowerPathRepository(
                 Id = x.Id,
                 Name = x.Name,
                 Description = x.Description,
-                Powers = x.PowerPathPowerMappings.AsQueryable()
+                Powers = x
+                    .PowerPathPowerMappings.AsQueryable()
                     .Where(y => powerIds.Contains(y.PowerId))
                     .OrderBy(y => y.OrderIndex)
                     .Select(PowerInformation.Selector())
-                    .ToList()
+                    .ToList(),
             })
             .ToListAsync(cancellationToken);
 

--- a/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerList/PowerInformation.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerList/PowerInformation.cs
@@ -1,57 +1,59 @@
 using System.Linq.Expressions;
-using ExpressedRealms.DB.Models.Powers;
+using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 
 namespace ExpressedRealms.Powers.Repository.Powers.DTOs.PowerList;
 
 public class PowerInformation
 {
-    public static readonly Expression<Func<Power, PowerInformation>> Selector =
-        x => new PowerInformation
+    public static Expression<Func<PowerPathPowerMapping, PowerInformation>> Selector()
+    {
+        return x => new PowerInformation
         {
-            Id = x.Id,
-            Name = x.Name,
-            Category = x
+            Id = x.Power.Id,
+            Name = x.Power.Name,
+            Category = x.Power
                 .CategoryMappings.Select(y => new DetailedInformation(
                     y.Category.Name,
                     y.Category.Description
                 ))
                 .ToList(),
-            Description = x.Description,
-            GameMechanicEffect = x.GameMechanicEffect ?? string.Empty,
-            Limitation = x.Limitation ?? string.Empty,
+            Description = x.Power.Description,
+            GameMechanicEffect = x.Power.GameMechanicEffect ?? string.Empty,
+            Limitation = x.Power.Limitation ?? string.Empty,
             PowerDuration = new DetailedInformation(
-                x.PowerDuration.Name,
-                x.PowerDuration.Description
+                x.Power.PowerDuration.Name,
+                x.Power.PowerDuration.Description
             ),
             AreaOfEffect = new DetailedInformation(
-                x.PowerAreaOfEffectType.Name,
-                x.PowerAreaOfEffectType.Description
+                x.Power.PowerAreaOfEffectType.Name,
+                x.Power.PowerAreaOfEffectType.Description
             ),
             PowerLevel = new DetailedInformation(
-                x.PowerLevel.Id,
-                x.PowerLevel.Name,
-                x.PowerLevel.Description
+                x.Power.PowerLevel.Id,
+                x.Power.PowerLevel.Name,
+                x.Power.PowerLevel.Description
             ),
             PowerActivationType = new DetailedInformation(
-                x.PowerActivationTimingType.Name,
-                x.PowerActivationTimingType.Description
+                x.Power.PowerActivationTimingType.Name,
+                x.Power.PowerActivationTimingType.Description
             ),
-            Other = x.OtherFields,
-            IsPowerUse = x.IsPowerUse,
-            Cost = x.Cost,
+            Other = x.Power.OtherFields,
+            IsPowerUse = x.Power.IsPowerUse,
+            Cost = x.Power.Cost,
             SortOrder = x.OrderIndex,
             Prerequisites =
-                x.Prerequisite != null
+                x.Power.Prerequisite != null
                     ? new PrerequisiteDetails
                     {
-                        RequiredAmount = x.Prerequisite.RequiredAmount,
-                        Powers = x
+                        RequiredAmount = x.Power.Prerequisite.RequiredAmount,
+                        Powers = x.Power
                             .Prerequisite.PrerequisitePowers.Select(pp => pp.Power.Name)
                             .ToList(),
                     }
                     : null,
-            ModifierGroupId = x.StatModifierGroupId,
+            ModifierGroupId = x.Power.StatModifierGroupId,
         };
+    }
 
     public int? ModifierGroupId { get; set; }
 

--- a/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerList/PowerInformation.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerList/PowerInformation.cs
@@ -11,8 +11,8 @@ public class PowerInformation
         {
             Id = x.Power.Id,
             Name = x.Power.Name,
-            Category = x.Power
-                .CategoryMappings.Select(y => new DetailedInformation(
+            Category = x
+                .Power.CategoryMappings.Select(y => new DetailedInformation(
                     y.Category.Name,
                     y.Category.Description
                 ))
@@ -46,8 +46,8 @@ public class PowerInformation
                     ? new PrerequisiteDetails
                     {
                         RequiredAmount = x.Power.Prerequisite.RequiredAmount,
-                        Powers = x.Power
-                            .Prerequisite.PrerequisitePowers.Select(pp => pp.Power.Name)
+                        Powers = x
+                            .Power.Prerequisite.PrerequisitePowers.Select(pp => pp.Power.Name)
                             .ToList(),
                     }
                     : null,

--- a/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerSorting/EditPowerSortModelValidator.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerSorting/EditPowerSortModelValidator.cs
@@ -24,13 +24,14 @@ public class EditPowerSortModelValidator : AbstractValidator<EditPowerSortModel>
                 async (dto, cancellationToken) =>
                 {
                     var powers = await dbContext
-                        .Powers.Where(x => x.PowerPathId == dto.PowerPathId)
+                        .PowerPathPowerMappings.Where(x => x.PowerPathId == dto.PowerPathId)
+                        .Select(x => x.Id)
                         .ToListAsync(cancellationToken);
 
                     return dto
                         .Items.Select(x => x.Id)
                         .OrderBy(id => id)
-                        .SequenceEqual(powers.Select(x => x.Id).OrderBy(id => id));
+                        .SequenceEqual(powers.Select(x => x).OrderBy(id => id));
                 }
             )
             .WithMessage(

--- a/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
@@ -37,7 +37,7 @@ internal sealed class PowerRepository(
                     ))
                     .ToList(),
                 Description = x.Power.Description,
-                GameMechanicEffect = x.Power.GameMechanicEffect,
+                GameMechanicEffect = x.Power.GameMechanicEffect!,
                 Limitation = x.Power.Limitation,
                 PowerDuration = new DetailedInformation(
                     x.Power.PowerDuration.Name,

--- a/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
@@ -30,8 +30,8 @@ internal sealed class PowerRepository(
             {
                 Id = x.Power.Id,
                 Name = x.Power.Name,
-                Category = x.Power
-                    .CategoryMappings.Select(y => new DetailedInformation(
+                Category = x
+                    .Power.CategoryMappings.Select(y => new DetailedInformation(
                         y.Category.Name,
                         y.Category.Description
                     ))
@@ -47,7 +47,10 @@ internal sealed class PowerRepository(
                     x.Power.PowerAreaOfEffectType.Name,
                     x.Power.PowerAreaOfEffectType.Description
                 ),
-                PowerLevel = new DetailedInformation(x.Power.PowerLevel.Name, x.Power.PowerLevel.Description),
+                PowerLevel = new DetailedInformation(
+                    x.Power.PowerLevel.Name,
+                    x.Power.PowerLevel.Description
+                ),
                 PowerActivationType = new DetailedInformation(
                     x.Power.PowerActivationTimingType.Name,
                     x.Power.PowerActivationTimingType.Description
@@ -171,12 +174,14 @@ internal sealed class PowerRepository(
         context.Powers.Add(newPower);
         await context.SaveChangesAsync(cancellationToken);
 
-        context.PowerPathPowerMappings.Add(new PowerPathPowerMapping()
-        {
-            PowerId = newPower.Id,
-            PowerPathId = createPowerModel.PowerPathId,
-            OrderIndex = nextPlaceOnList + 1
-        });
+        context.PowerPathPowerMappings.Add(
+            new PowerPathPowerMapping()
+            {
+                PowerId = newPower.Id,
+                PowerPathId = createPowerModel.PowerPathId,
+                OrderIndex = nextPlaceOnList + 1,
+            }
+        );
 
         if (createPowerModel.Category == null || createPowerModel.Category.Count == 0)
         {
@@ -303,7 +308,9 @@ internal sealed class PowerRepository(
         return await context
             .Powers.AsNoTracking()
             .AnyAsync(
-                x => x.Id == powerId && x.PowerPathPowerMapping!.PowerPath.ExpressionId == characterExpressionId,
+                x =>
+                    x.Id == powerId
+                    && x.PowerPathPowerMapping!.PowerPath.ExpressionId == characterExpressionId,
                 cancellationToken
             );
     }

--- a/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
@@ -1,6 +1,7 @@
 using ExpressedRealms.DB;
 using ExpressedRealms.DB.Interceptors;
 using ExpressedRealms.DB.Models.Powers;
+using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.Options;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerCreate;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerEdit;
@@ -23,44 +24,44 @@ internal sealed class PowerRepository(
     public async Task<Result<List<PowerInformation>>> GetPowersAsync(int powerPathId)
     {
         var items = await context
-            .Powers.Where(x => x.PowerPathId == powerPathId)
+            .PowerPathPowerMappings.Where(x => x.PowerPathId == powerPathId)
             .OrderBy(x => x.OrderIndex)
             .Select(x => new PowerInformation
             {
-                Id = x.Id,
-                Name = x.Name,
-                Category = x
+                Id = x.Power.Id,
+                Name = x.Power.Name,
+                Category = x.Power
                     .CategoryMappings.Select(y => new DetailedInformation(
                         y.Category.Name,
                         y.Category.Description
                     ))
                     .ToList(),
-                Description = x.Description,
-                GameMechanicEffect = x.GameMechanicEffect,
-                Limitation = x.Limitation,
+                Description = x.Power.Description,
+                GameMechanicEffect = x.Power.GameMechanicEffect,
+                Limitation = x.Power.Limitation,
                 PowerDuration = new DetailedInformation(
-                    x.PowerDuration.Name,
-                    x.PowerDuration.Description
+                    x.Power.PowerDuration.Name,
+                    x.Power.PowerDuration.Description
                 ),
                 AreaOfEffect = new DetailedInformation(
-                    x.PowerAreaOfEffectType.Name,
-                    x.PowerAreaOfEffectType.Description
+                    x.Power.PowerAreaOfEffectType.Name,
+                    x.Power.PowerAreaOfEffectType.Description
                 ),
-                PowerLevel = new DetailedInformation(x.PowerLevel.Name, x.PowerLevel.Description),
+                PowerLevel = new DetailedInformation(x.Power.PowerLevel.Name, x.Power.PowerLevel.Description),
                 PowerActivationType = new DetailedInformation(
-                    x.PowerActivationTimingType.Name,
-                    x.PowerActivationTimingType.Description
+                    x.Power.PowerActivationTimingType.Name,
+                    x.Power.PowerActivationTimingType.Description
                 ),
-                Other = x.OtherFields,
-                IsPowerUse = x.IsPowerUse,
-                Cost = x.Cost,
+                Other = x.Power.OtherFields,
+                IsPowerUse = x.Power.IsPowerUse,
+                Cost = x.Power.Cost,
                 Prerequisites =
-                    x.Prerequisite != null
+                    x.Power.Prerequisite != null
                         ? new PrerequisiteDetails()
                         {
-                            RequiredAmount = x.Prerequisite.RequiredAmount,
+                            RequiredAmount = x.Power.Prerequisite.RequiredAmount,
                             Powers = x
-                                .Prerequisite.PrerequisitePowers.Select(x => x.Power.Name)
+                                .Power.Prerequisite.PrerequisitePowers.Select(x => x.Power.Name)
                                 .ToList(),
                         }
                         : null,
@@ -148,7 +149,7 @@ internal sealed class PowerRepository(
             return Result.Fail(result.Errors);
 
         var nextPlaceOnList = await context
-            .Powers.AsNoTracking()
+            .PowerPathPowerMappings.AsNoTracking()
             .Where(x => x.PowerPathId == createPowerModel.PowerPathId)
             .CountAsync();
 
@@ -172,8 +173,16 @@ internal sealed class PowerRepository(
         context.Powers.Add(newPower);
         await context.SaveChangesAsync(cancellationToken);
 
+        context.PowerPathPowerMappings.Add(new PowerPathPowerMapping()
+        {
+            PowerId = newPower.Id,
+            PowerPathId = createPowerModel.PowerPathId,
+            OrderIndex = nextPlaceOnList + 1
+        });
+
         if (createPowerModel.Category == null || createPowerModel.Category.Count == 0)
         {
+            await context.SaveChangesAsync(cancellationToken);
             return Result.Ok(newPower.Id);
         }
 
@@ -266,7 +275,7 @@ internal sealed class PowerRepository(
     public async Task<Result> UpdatePowerPathSortOrder(EditPowerSortModel dto)
     {
         var sections = await context
-            .Powers.Where(x => x.PowerPathId == dto.PowerPathId)
+            .PowerPathPowerMappings.Where(x => x.PowerPathId == dto.PowerPathId)
             .ToListAsync();
 
         foreach (var item in dto.Items)

--- a/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
@@ -278,7 +278,7 @@ internal sealed class PowerRepository(
 
         foreach (var item in dto.Items)
         {
-            var section = sections.First(x => x.Id == item.Id);
+            var section = sections.First(x => x.PowerId == item.Id);
             section.OrderIndex = item.SortOrder;
         }
 

--- a/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
@@ -161,13 +161,11 @@ internal sealed class PowerRepository(
             AreaOfEffectTypeId = createPowerModel.AreaOfEffect,
             ActivationTimingTypeId = createPowerModel.PowerActivationType,
             DurationId = createPowerModel.PowerDuration,
-            PowerPathId = createPowerModel.PowerPathId,
             IsPowerUse = createPowerModel.IsPowerUse,
             GameMechanicEffect = createPowerModel.GameMechanicEffect,
             Limitation = createPowerModel.Limitation,
             OtherFields = createPowerModel.Other,
             Cost = createPowerModel.Cost,
-            OrderIndex = nextPlaceOnList + 1,
         };
 
         context.Powers.Add(newPower);
@@ -305,7 +303,7 @@ internal sealed class PowerRepository(
         return await context
             .Powers.AsNoTracking()
             .AnyAsync(
-                x => x.Id == powerId && x.PowerPath.ExpressionId == characterExpressionId,
+                x => x.Id == powerId && x.PowerPathPowerMapping!.PowerPath.ExpressionId == characterExpressionId,
                 cancellationToken
             );
     }


### PR DESCRIPTION
Overview
 - I detangled power paths and powers - it's no longer a parent child relationship, there's now a mapping table between the two
 - This makes powers a bit more independent, and allows me to assign powers to other things in the tool, such as Faction Levels, or creatures (think custom power for a creature)
 - Removed Path Id and Order Index from Powers
   - The mapping table will keep track of this now
   - Means we loose audit logs on sort order - which I'm okay with
 - Updated activity logs with new table info

Testing / notes
  - Check Adding a Power
  - Check Updating Power Path Sort Order
  - Editing is not requried - moved fields are not modified directly here
  - Get Power not needed - two fields are not passed through to the front end
  - Selected Powers are being loaded in for the given character, both in character wizard and sheet power list
  - Delete Powers
