### PR TITLE
Add Basic Faction API + Use Cases + Endpoints

### DIFF
--- a/api/ExpressedRealms.Authentication/PermissionCollection/Expressions/FactionResource.cs
+++ b/api/ExpressedRealms.Authentication/PermissionCollection/Expressions/FactionResource.cs
@@ -1,0 +1,39 @@
+using ExpressedRealms.Authentication.PermissionCollection.Support;
+
+namespace ExpressedRealms.Authentication.PermissionCollection;
+
+public static partial class Permissions
+{
+    public static class Faction
+    {
+        private static readonly ResourceInfo ResourceInfo = new()
+        {
+            Id = new Guid("019f0362-a536-745c-8a8d-276def1079ea"),
+            Name = nameof(Faction),
+        };
+
+        public static readonly Permission Edit = new(ResourceInfo)
+        {
+            Id = new Guid("019f0362-a536-7f6d-9392-e0d2f5914f6a"),
+            Name = nameof(Edit),
+        };
+
+        public static readonly Permission View = new(ResourceInfo)
+        {
+            Id = new Guid("019f0362-a536-7817-b18f-4d2347eb83dd"),
+            Name = nameof(View),
+        };
+
+        public static readonly Permission Create = new(ResourceInfo)
+        {
+            Id = new Guid("019f0362-a536-7ff3-be70-6ae0a570c37a"),
+            Name = nameof(Create),
+        };
+
+        public static readonly Permission Delete = new(ResourceInfo)
+        {
+            Id = new Guid("019f0362-a536-75da-a245-afdc982b64d4"),
+            Name = nameof(Delete),
+        };
+    }
+}

--- a/api/ExpressedRealms.DB/Models/Factions/FactionModels/Faction.cs
+++ b/api/ExpressedRealms.DB/Models/Factions/FactionModels/Faction.cs
@@ -9,8 +9,8 @@ public class Faction : ISoftDelete
 {
     public int Id { get; set; }
     public int ExpressionId { get; set; }
-    public required string Name { get; set; }
-    public required string Background { get; set; }
+    public string Name { get; set; } = null!;
+    public string Background { get; set; } = null!;
 
     public bool IsDeleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }

--- a/api/ExpressedRealms.Expressions.API/Configuration/ExpressionsApiConfiguration.cs
+++ b/api/ExpressedRealms.Expressions.API/Configuration/ExpressionsApiConfiguration.cs
@@ -1,12 +1,13 @@
 using ExpressedRealms.Expressions.API.ExpressionEndpoints;
 using ExpressedRealms.Expressions.API.ExpressionSubSectionEndpoints;
+using ExpressedRealms.Expressions.API.FactionEndpoints;
 using ExpressedRealms.Expressions.API.ProgressionPaths;
 using ExpressedRealms.Expressions.API.StatModifiers;
 using Microsoft.AspNetCore.Builder;
 
 namespace ExpressedRealms.Expressions.API.Configuration;
 
-public static class ExpressionsAPIConfiguration
+public static class ExpressionsApiConfiguration
 {
     public static void AddExpressionEndPoints(this WebApplication app)
     {
@@ -14,5 +15,6 @@ public static class ExpressionsAPIConfiguration
         app.AddExpressionSubsectionEndpoints();
         app.AddProgressionEndpoints();
         app.AddStatModifiersEndpoints();
+        app.AddFactionEndpoints();
     }
 }

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/CreateFaction/CreateFactionEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/CreateFaction/CreateFactionEndpoint.cs
@@ -1,0 +1,34 @@
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.CreateFaction;
+using ExpressedRealms.Server.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.CreateFaction;
+
+public static class CreateFactionEndpoint
+{
+    public static async Task<Results<Ok<int>, NotFound, ValidationProblem>> ExecuteAsync(
+        [FromBody] CreateFactionRequest request,
+        [FromServices] ICreateFactionUseCase createFactionUseCase
+    )
+    {
+        var results = await createFactionUseCase.ExecuteAsync(
+            new CreateFactionModel()
+            {
+                Name = request.Name,
+                Background = request.Background,
+                ExpressionId = request.ExpressionId,
+            }
+        );
+
+        if (results.HasValidationError(out var validationProblem))
+            return validationProblem;
+        if (results.HasNotFound(out var notFound))
+            return notFound;
+
+        results.ThrowIfErrorNotHandled();
+
+        return TypedResults.Ok(results.Value);
+    }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/CreateFaction/CreateFactionRequest.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/CreateFaction/CreateFactionRequest.cs
@@ -1,0 +1,8 @@
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.CreateFaction;
+
+public class CreateFactionRequest
+{
+    public required string Name { get; set; }
+    public required string Background { get; set; }
+    public required int ExpressionId { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/DeleteFaction/DeleteFactionEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/DeleteFaction/DeleteFactionEndpoint.cs
@@ -1,0 +1,27 @@
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.DeleteFaction;
+using ExpressedRealms.Server.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.DeleteFaction;
+
+public static class DeleteFactionEndpoint
+{
+    public static async Task<Results<Ok, NotFound, ValidationProblem>> ExecuteAsync(
+        int id,
+        [FromServices] IDeleteFactionUseCase useCase
+    )
+    {
+        var results = await useCase.ExecuteAsync(new DeleteFactionModel() { Id = id });
+
+        if (results.HasValidationError(out var validationProblem))
+            return validationProblem;
+        if (results.HasNotFound(out var notFound))
+            return notFound;
+
+        results.ThrowIfErrorNotHandled();
+
+        return TypedResults.Ok();
+    }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/EditFaction/EditFactionEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/EditFaction/EditFactionEndpoint.cs
@@ -1,0 +1,35 @@
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.EditFaction;
+using ExpressedRealms.Server.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.EditFaction;
+
+public static class EditFactionEndpoint
+{
+    public static async Task<Results<Ok, NotFound, ValidationProblem>> ExecuteAsync(
+        int id,
+        [FromBody] EditFactionRequest request,
+        [FromServices] IEditFactionUseCase editFactionUseCase
+    )
+    {
+        var results = await editFactionUseCase.ExecuteAsync(
+            new EditFactionModel()
+            {
+                Id = id,
+                Name = request.Name,
+                Background = request.Background,
+            }
+        );
+
+        if (results.HasValidationError(out var validationProblem))
+            return validationProblem;
+        if (results.HasNotFound(out var notFound))
+            return notFound;
+
+        results.ThrowIfErrorNotHandled();
+
+        return TypedResults.Ok();
+    }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/EditFaction/EditFactionRequest.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/EditFaction/EditFactionRequest.cs
@@ -1,0 +1,7 @@
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.EditFaction;
+
+public class EditFactionRequest
+{
+    public required string Name { get; set; }
+    public required string Background { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
@@ -18,16 +18,20 @@ internal static class FactionEndpoints
 
         endpointGroup.MapGet("expressions/{expressionId}", GetFactionsEndpoint.ExecuteAsync);
 
-        endpointGroup.MapGet("{id}", GetFactionEndpoint.ExecuteAsync)
+        endpointGroup
+            .MapGet("{id}", GetFactionEndpoint.ExecuteAsync)
             .RequirePermission(Permissions.Faction.View);
 
-        endpointGroup.MapPost("", CreateFactionEndpoint.ExecuteAsync)
+        endpointGroup
+            .MapPost("", CreateFactionEndpoint.ExecuteAsync)
             .RequirePermission(Permissions.Faction.Create);
 
-        endpointGroup.MapPut("{id}", EditFactionEndpoint.ExecuteAsync)
+        endpointGroup
+            .MapPut("{id}", EditFactionEndpoint.ExecuteAsync)
             .RequirePermission(Permissions.Faction.Edit);
 
-        endpointGroup.MapDelete("{id}", DeleteFactionEndpoint.ExecuteAsync)
+        endpointGroup
+            .MapDelete("{id}", DeleteFactionEndpoint.ExecuteAsync)
             .RequirePermission(Permissions.Faction.Delete);
     }
 }

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
@@ -1,0 +1,27 @@
+using ExpressedRealms.Expressions.API.FactionEndpoints.CreateFaction;
+using ExpressedRealms.Expressions.API.FactionEndpoints.DeleteFaction;
+using ExpressedRealms.Expressions.API.FactionEndpoints.EditFaction;
+using ExpressedRealms.Expressions.API.FactionEndpoints.GetFaction;
+using ExpressedRealms.Expressions.API.FactionEndpoints.GetFactions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace ExpressedRealms.Expressions.API.FactionEndpoints;
+
+internal static class FactionEndpoints
+{
+    internal static void AddFactionEndpoints(this WebApplication app)
+    {
+        var endpointGroup = app.MapGroup("factions").WithTags("Factions").RequireAuthorization();
+
+        endpointGroup.MapGet("", GetFactionsEndpoint.ExecuteAsync);
+
+        endpointGroup.MapGet("{id}", GetFactionEndpoint.ExecuteAsync);
+
+        endpointGroup.MapPost("", CreateFactionEndpoint.ExecuteAsync);
+
+        endpointGroup.MapPut("{id}", EditFactionEndpoint.ExecuteAsync);
+
+        endpointGroup.MapDelete("{id}", DeleteFactionEndpoint.ExecuteAsync);
+    }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
@@ -1,3 +1,5 @@
+using ExpressedRealms.Authentication.PermissionCollection;
+using ExpressedRealms.Authentication.PermissionCollection.Configuration;
 using ExpressedRealms.Expressions.API.FactionEndpoints.CreateFaction;
 using ExpressedRealms.Expressions.API.FactionEndpoints.DeleteFaction;
 using ExpressedRealms.Expressions.API.FactionEndpoints.EditFaction;
@@ -14,14 +16,18 @@ internal static class FactionEndpoints
     {
         var endpointGroup = app.MapGroup("factions").WithTags("Factions").RequireAuthorization();
 
-        endpointGroup.MapGet("", GetFactionsEndpoint.ExecuteAsync);
+        endpointGroup.MapGet("expressions/{expressionId}", GetFactionsEndpoint.ExecuteAsync);
 
-        endpointGroup.MapGet("{id}", GetFactionEndpoint.ExecuteAsync);
+        endpointGroup.MapGet("{id}", GetFactionEndpoint.ExecuteAsync)
+            .RequirePermission(Permissions.Faction.View);
 
-        endpointGroup.MapPost("", CreateFactionEndpoint.ExecuteAsync);
+        endpointGroup.MapPost("", CreateFactionEndpoint.ExecuteAsync)
+            .RequirePermission(Permissions.Faction.Create);
 
-        endpointGroup.MapPut("{id}", EditFactionEndpoint.ExecuteAsync);
+        endpointGroup.MapPut("{id}", EditFactionEndpoint.ExecuteAsync)
+            .RequirePermission(Permissions.Faction.Edit);
 
-        endpointGroup.MapDelete("{id}", DeleteFactionEndpoint.ExecuteAsync);
+        endpointGroup.MapDelete("{id}", DeleteFactionEndpoint.ExecuteAsync)
+            .RequirePermission(Permissions.Faction.Delete);
     }
 }

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFaction/GetFactionEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFaction/GetFactionEndpoint.cs
@@ -1,0 +1,25 @@
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFaction;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.GetFaction;
+
+public static class GetFactionEndpoint
+{
+    public static async Task<Ok<GetFactionResponse>> ExecuteAsync(
+        int id,
+        IGetFactionUseCase createFactionUseCase
+    )
+    {
+        var results = await createFactionUseCase.ExecuteAsync(new GetFactionModel() { Id = id });
+
+        return TypedResults.Ok(
+            new GetFactionResponse()
+            {
+                Id = results.Value.Id,
+                Name = results.Value.Name,
+                Background = results.Value.Background
+            }
+        );
+    }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFaction/GetFactionEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFaction/GetFactionEndpoint.cs
@@ -18,7 +18,7 @@ public static class GetFactionEndpoint
             {
                 Id = results.Value.Id,
                 Name = results.Value.Name,
-                Background = results.Value.Background
+                Background = results.Value.Background,
             }
         );
     }

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFaction/GetFactionResponse.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFaction/GetFactionResponse.cs
@@ -1,0 +1,8 @@
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.GetFaction;
+
+public class GetFactionResponse
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public required string Background { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/FactionResponse.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/FactionResponse.cs
@@ -1,0 +1,6 @@
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.GetFactions;
+
+public class FactionResponse
+{
+    public List<FactionViewModel> Factions { get; set; } = new();
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/FactionViewModel.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/FactionViewModel.cs
@@ -1,0 +1,8 @@
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.GetFactions;
+
+public class FactionViewModel
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public required string Background { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
@@ -1,0 +1,33 @@
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace ExpressedRealms.Expressions.API.FactionEndpoints.GetFactions;
+
+public static class GetFactionsEndpoint
+{
+    public static async Task<Ok<FactionResponse>> ExecuteAsync(
+        int expressionId,
+        IGetFactionsUseCase createFactionUseCase
+    )
+    {
+        var results = await createFactionUseCase.ExecuteAsync(new GetFactionsModel()
+        {
+            ExpressionId = expressionId
+        });
+
+        return TypedResults.Ok(
+            new FactionResponse()
+            {
+                Factions = results
+                    .Value.Factions.Select(x => new FactionViewModel()
+                    {
+                        Id = x.Id,
+                        Name = x.Name,
+                        Background = x.Background
+                    })
+                    .ToList(),
+            }
+        );
+    }
+}

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
@@ -11,10 +11,9 @@ public static class GetFactionsEndpoint
         IGetFactionsUseCase createFactionUseCase
     )
     {
-        var results = await createFactionUseCase.ExecuteAsync(new GetFactionsModel()
-        {
-            ExpressionId = expressionId
-        });
+        var results = await createFactionUseCase.ExecuteAsync(
+            new GetFactionsModel() { ExpressionId = expressionId }
+        );
 
         return TypedResults.Ok(
             new FactionResponse()
@@ -24,7 +23,7 @@ public static class GetFactionsEndpoint
                     {
                         Id = x.Id,
                         Name = x.Name,
-                        Background = x.Background
+                        Background = x.Background,
                     })
                     .ToList(),
             }

--- a/api/ExpressedRealms.Expressions.Repository/ExpressionRepositoryInjections.cs
+++ b/api/ExpressedRealms.Expressions.Repository/ExpressionRepositoryInjections.cs
@@ -2,6 +2,7 @@ using ExpressedRealms.Expressions.Repository.Expressions;
 using ExpressedRealms.Expressions.Repository.Expressions.DTOs;
 using ExpressedRealms.Expressions.Repository.ExpressionTextSections;
 using ExpressedRealms.Expressions.Repository.ExpressionTextSections.DTOs;
+using ExpressedRealms.Expressions.Repository.Factions;
 using ExpressedRealms.Expressions.Repository.ProgressionPaths;
 using ExpressedRealms.Expressions.Repository.StatModifier;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +27,7 @@ public static class ExpressionRepositoryInjections
         services.AddScoped<IExpressionTextSectionRepository, ExpressionTextSectionRepository>();
         services.AddScoped<IProgressionPathRepository, ProgressionPathRepository>();
         services.AddScoped<IStatModifierRepository, StatModifierRepository>();
+        services.AddScoped<IFactionRepository, FactionRepository>();
         return services;
     }
 }

--- a/api/ExpressedRealms.Expressions.Repository/Expressions/ExpressionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Expressions/ExpressionRepository.cs
@@ -335,6 +335,11 @@ internal sealed class ExpressionRepository(
         return await context.ExpressionTypes.AnyAsync(x => x.Id == id, cancellationToken);
     }
 
+    public async Task<bool> ExpressionIsExpressionType(int expressionId)
+    {
+        return await context.Expressions.AnyAsync(x => x.Id == expressionId && x.ExpressionTypeId == 1, cancellationToken);
+    }
+
     public async Task<List<Expression>> GetAllEnabledExpressions()
     {
         return await context.Expressions.Where(x => x.ExpressionTypeId == 1).ToListAsync(); // 1 = expression

--- a/api/ExpressedRealms.Expressions.Repository/Expressions/ExpressionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Expressions/ExpressionRepository.cs
@@ -337,7 +337,10 @@ internal sealed class ExpressionRepository(
 
     public async Task<bool> ExpressionIsExpressionType(int expressionId)
     {
-        return await context.Expressions.AnyAsync(x => x.Id == expressionId && x.ExpressionTypeId == 1, cancellationToken);
+        return await context.Expressions.AnyAsync(
+            x => x.Id == expressionId && x.ExpressionTypeId == 1,
+            cancellationToken
+        );
     }
 
     public async Task<List<Expression>> GetAllEnabledExpressions()

--- a/api/ExpressedRealms.Expressions.Repository/Expressions/IExpressionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Expressions/IExpressionRepository.cs
@@ -20,4 +20,5 @@ public interface IExpressionRepository
     Task<Result<GetExpressionDto>> CheckUserPermissionsForExpressionDelete(int expressionId);
     Task<Result<GetExpressionDto>> CheckUserPermissionsForExpressionCreate(int expressionId);
     Task<Result<GetExpressionDto>> CheckUserPermissionsForExpressionView(int expressionId);
+    Task<bool> ExpressionIsExpressionType(int expressionId);
 }

--- a/api/ExpressedRealms.Expressions.Repository/Factions/FactionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Factions/FactionRepository.cs
@@ -45,7 +45,8 @@ internal sealed class FactionRepository(
 
     public async Task<List<Faction>> GetFactions(int expressionId)
     {
-        return await context.Factions.AsNoTracking()
+        return await context
+            .Factions.AsNoTracking()
             .Where(x => x.ExpressionId == expressionId)
             .ToListAsync(cancellationToken);
     }

--- a/api/ExpressedRealms.Expressions.Repository/Factions/FactionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Factions/FactionRepository.cs
@@ -1,0 +1,59 @@
+using ExpressedRealms.DB;
+using ExpressedRealms.DB.Models.Factions.FactionModels;
+using Microsoft.EntityFrameworkCore;
+
+namespace ExpressedRealms.Expressions.Repository.Factions;
+
+internal sealed class FactionRepository(
+    ExpressedRealmsDbContext context,
+    CancellationToken cancellationToken
+) : IFactionRepository
+{
+    public async Task<int> CreateFactionAsync(Faction faction)
+    {
+        context.Factions.Add(faction);
+        await context.SaveChangesAsync(cancellationToken);
+        return faction.Id;
+    }
+
+    public async Task<bool> HasDuplicateName(string name, int factionId = 0)
+    {
+        if (factionId != 0)
+        {
+            return await context
+                .Factions.AsNoTracking()
+                .AnyAsync(
+                    x => x.Name.ToLower() == name.ToLower() && x.Id != factionId,
+                    cancellationToken
+                );
+        }
+        return await context
+            .Factions.AsNoTracking()
+            .AnyAsync(x => x.Name.ToLower() == name.ToLower(), cancellationToken);
+    }
+
+    public async Task EditFactionAsync(Faction faction)
+    {
+        context.Factions.Update(faction);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<Faction?> GetFactionForEditingAsync(int id)
+    {
+        return context.Factions.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+
+    public async Task<List<Faction>> GetFactions(int expressionId)
+    {
+        return await context.Factions.AsNoTracking()
+            .Where(x => x.ExpressionId == expressionId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public Task<Faction?> GetFactionAsync(int id)
+    {
+        return context
+            .Factions.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+}

--- a/api/ExpressedRealms.Expressions.Repository/Factions/IFactionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Factions/IFactionRepository.cs
@@ -1,0 +1,13 @@
+using ExpressedRealms.DB.Models.Factions.FactionModels;
+
+namespace ExpressedRealms.Expressions.Repository.Factions;
+
+public interface IFactionRepository
+{
+    Task<int> CreateFactionAsync(Faction faction);
+    Task<bool> HasDuplicateName(string name, int factionId = 0);
+    Task EditFactionAsync(Faction faction);
+    Task<Faction?> GetFactionForEditingAsync(int id);
+    Task<List<Faction>> GetFactions(int expressionId);
+    Task<Faction?> GetFactionAsync(int id);
+}

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/CreateFactionUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/CreateFactionUseCaseTests.cs
@@ -26,13 +26,19 @@ public class CreateFactionUseCaseTests
 
         _factionRepository = A.Fake<IFactionRepository>();
         _expressionRepository = A.Fake<IExpressionRepository>();
-        
-        A.CallTo(() => _expressionRepository.ExpressionIsExpressionType(_model.ExpressionId)).Returns(true);
+
+        A.CallTo(() => _expressionRepository.ExpressionIsExpressionType(_model.ExpressionId))
+            .Returns(true);
         A.CallTo(() => _factionRepository.HasDuplicateName(_model.Name)).Returns(false);
-        
+
         var validator = new CreateFactionModelValidator();
 
-        _useCase = new CreateFactionUseCase(_factionRepository, _expressionRepository, validator, CancellationToken.None);
+        _useCase = new CreateFactionUseCase(
+            _factionRepository,
+            _expressionRepository,
+            validator,
+            CancellationToken.None
+        );
     }
 
     [Fact]
@@ -91,23 +97,30 @@ public class CreateFactionUseCaseTests
             "Background cannot exceed 20000 characters."
         );
     }
-    
+
     [Fact]
     public async Task ValidationFor_ExpressionId_WillFail_WhenItIsEmpty()
     {
         _model.ExpressionId = 0;
 
         var results = await _useCase.ExecuteAsync(_model);
-        results.MustHaveValidationError(nameof(CreateFactionModel.ExpressionId), "Expression Id is required.");
+        results.MustHaveValidationError(
+            nameof(CreateFactionModel.ExpressionId),
+            "Expression Id is required."
+        );
     }
-    
+
     [Fact]
     public async Task ValidationFor_ExpressionId_WillFail_WhenExpressionId_IsNotAnExpression()
     {
-        A.CallTo(() => _expressionRepository.ExpressionIsExpressionType(_model.ExpressionId)).Returns(false);
+        A.CallTo(() => _expressionRepository.ExpressionIsExpressionType(_model.ExpressionId))
+            .Returns(false);
 
         var results = await _useCase.ExecuteAsync(_model);
-        results.MustHaveValidationError(nameof(CreateFactionModel.ExpressionId), "Expression Id is not of an expression type.");
+        results.MustHaveValidationError(
+            nameof(CreateFactionModel.ExpressionId),
+            "Expression Id is not of an expression type."
+        );
     }
 
     [Fact]

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/CreateFactionUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/CreateFactionUseCaseTests.cs
@@ -1,0 +1,144 @@
+using ExpressedRealms.DB.Models.Factions.FactionModels;
+using ExpressedRealms.Expressions.Repository.Expressions;
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.CreateFaction;
+using ExpressedRealms.Shared.UseCases.Tests.Unit;
+using FakeItEasy;
+using Xunit;
+
+namespace ExpressedRealms.Expressions.UseCases.Tests.Unit.Factions;
+
+public class CreateFactionUseCaseTests
+{
+    private readonly CreateFactionUseCase _useCase;
+    private readonly IFactionRepository _factionRepository;
+    private readonly IExpressionRepository _expressionRepository;
+    private readonly CreateFactionModel _model;
+
+    public CreateFactionUseCaseTests()
+    {
+        _model = new CreateFactionModel()
+        {
+            Name = "parse",
+            Background = "View",
+            ExpressionId = 1,
+        };
+
+        _factionRepository = A.Fake<IFactionRepository>();
+        _expressionRepository = A.Fake<IExpressionRepository>();
+        
+        A.CallTo(() => _expressionRepository.ExpressionIsExpressionType(_model.ExpressionId)).Returns(true);
+        A.CallTo(() => _factionRepository.HasDuplicateName(_model.Name)).Returns(false);
+        
+        var validator = new CreateFactionModelValidator();
+
+        _useCase = new CreateFactionUseCase(_factionRepository, _expressionRepository, validator, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ValidationFor_Name_WillFail_WhenName_IsEmpty()
+    {
+        _model.Name = string.Empty;
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(nameof(CreateFactionModel.Name), "Name is required.");
+    }
+
+    [Fact]
+    public async Task ValidationFor_Name_WillFail_WhenName_IsOver250Characters()
+    {
+        _model.Name = new string('x', 251);
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(
+            nameof(CreateFactionModel.Name),
+            "Name cannot exceed 250 characters."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_Name_WillFail_WhenName_IsADuplicateName()
+    {
+        A.CallTo(() => _factionRepository.HasDuplicateName(_model.Name)).Returns(true);
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(
+            nameof(CreateFactionModel.Name),
+            "This name already exists."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_Background_WillFail_WhenBackground_IsEmpty()
+    {
+        _model.Background = string.Empty;
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(
+            nameof(CreateFactionModel.Background),
+            "Background is required."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_Background_WillFail_WhenBackground_IsOver20000Characters()
+    {
+        _model.Background = new string('x', 20001);
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(
+            nameof(CreateFactionModel.Background),
+            "Background cannot exceed 20000 characters."
+        );
+    }
+    
+    [Fact]
+    public async Task ValidationFor_ExpressionId_WillFail_WhenItIsEmpty()
+    {
+        _model.ExpressionId = 0;
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(nameof(CreateFactionModel.ExpressionId), "Expression Id is required.");
+    }
+    
+    [Fact]
+    public async Task ValidationFor_ExpressionId_WillFail_WhenExpressionId_IsNotAnExpression()
+    {
+        A.CallTo(() => _expressionRepository.ExpressionIsExpressionType(_model.ExpressionId)).Returns(false);
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(nameof(CreateFactionModel.ExpressionId), "Expression Id is not of an expression type.");
+    }
+
+    [Fact]
+    public async Task UseCase_WillCreateTheFaction()
+    {
+        var faction = new Faction()
+        {
+            Name = _model.Name,
+            Background = _model.Background,
+            ExpressionId = _model.ExpressionId,
+        };
+
+        await _useCase.ExecuteAsync(_model);
+        A.CallTo(() =>
+                _factionRepository.CreateFactionAsync(
+                    A<Faction>.That.Matches(k =>
+                        k.Name == faction.Name
+                        && k.Background == faction.Background
+                        && k.ExpressionId == faction.ExpressionId
+                    )
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillReturn_FactionId_IfSuccessful()
+    {
+        A.CallTo(() => _factionRepository.CreateFactionAsync(A<Faction>._)).Returns(5);
+
+        var result = await _useCase.ExecuteAsync(_model);
+        Assert.Equal(5, result.Value);
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/DeleteFactionUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/DeleteFactionUseCaseTests.cs
@@ -1,0 +1,72 @@
+using ExpressedRealms.DB.Models.Factions.FactionModels;
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.DeleteFaction;
+using ExpressedRealms.Shared.UseCases.Tests.Unit;
+using FakeItEasy;
+using Xunit;
+
+namespace ExpressedRealms.Expressions.UseCases.Tests.Unit.Factions;
+
+public class DeleteFactionUseCaseTests
+{
+    private readonly DeleteFactionUseCase _useCase;
+    private readonly IFactionRepository _repository;
+    private readonly DeleteFactionModel _model;
+
+    public DeleteFactionUseCaseTests()
+    {
+        _model = new DeleteFactionModel() { Id = 4 };
+
+        _repository = A.Fake<IFactionRepository>();
+
+        A.CallTo(() => _repository.GetFactionForEditingAsync(_model.Id))
+            .Returns(new Faction() { Id = _model.Id });
+
+        var validator = new DeleteFactionModelValidator();
+
+        _useCase = new DeleteFactionUseCase(_repository, validator, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ValidationFor_Id_WillFail_WhenId_IsEmpty()
+    {
+        _model.Id = 0;
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(nameof(DeleteFactionModel.Id), "Id is required.");
+    }
+
+    [Fact]
+    public async Task ValidationFor_Id_WillFail_WhenFactionDoesNotExist()
+    {
+        A.CallTo(() => _repository.GetFactionForEditingAsync(_model.Id))!
+            .Returns(Task.FromResult((Faction)null!));
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveNotFoundError(nameof(DeleteFactionModel.Id), "This Faction was not found.");
+    }
+
+    [Fact]
+    public async Task UseCase_WillGrab_TheFaction()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _repository.GetFactionForEditingAsync(_model.Id))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillSoftDelete_TheFaction()
+    {
+        var faction = new Faction() { Id = _model.Id, IsDeleted = true };
+
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() =>
+                _repository.EditFactionAsync(
+                    A<Faction>.That.Matches(k =>
+                        k.Id == faction.Id && k.IsDeleted == faction.IsDeleted
+                    )
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/EditFactionUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/EditFactionUseCaseTests.cs
@@ -1,0 +1,155 @@
+using ExpressedRealms.DB.Models.Factions.FactionModels;
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.CreateFaction;
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.EditFaction;
+using ExpressedRealms.Shared.UseCases.Tests.Unit;
+using FakeItEasy;
+using Xunit;
+
+namespace ExpressedRealms.Expressions.UseCases.Tests.Unit.Factions;
+
+public class EditFactionUseCaseTests
+{
+    private readonly EditFactionUseCase _useCase;
+    private readonly IFactionRepository _factionRepository;
+    private readonly EditFactionModel _model;
+    private readonly Faction _dbModel;
+
+    public EditFactionUseCaseTests()
+    {
+        _model = new EditFactionModel()
+        {
+            Id = 1,
+            Name = "parse",
+            Background = "View"
+        };
+
+        _dbModel = new Faction()
+        {
+            Name = "Intelligent Metal Towels",
+            Background = "Engineer",
+            ExpressionId = 1,
+        };
+
+        _factionRepository = A.Fake<IFactionRepository>();
+
+        A.CallTo(() => _factionRepository.GetFactionForEditingAsync(_model.Id)).Returns(_dbModel);
+        A.CallTo(() => _factionRepository.HasDuplicateName(_model.Name)).Returns(false);
+
+        var validator = new EditFactionModelValidator();
+
+        _useCase = new EditFactionUseCase(_factionRepository, validator, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ValidationFor_Id_WillFail_WhenId_IsEmpty()
+    {
+        _model.Id = 0;
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(nameof(EditFactionModel.Id), "Id is required.");
+    }
+
+    [Fact]
+    public async Task ValidationFor_Id_WillFail_WhenFactionDoesNotExist()
+    {
+        A.CallTo(() => _factionRepository.GetFactionForEditingAsync(_model.Id))!
+            .Returns(Task.FromResult((Faction)null!));
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveNotFoundError(nameof(EditFactionModel.Id), "This Faction was not found.");
+    }
+
+    [Fact]
+    public async Task ValidationFor_Name_WillFail_WhenName_IsEmpty()
+    {
+        _model.Name = string.Empty;
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(nameof(EditFactionModel.Name), "Name is required.");
+    }
+
+    [Fact]
+    public async Task ValidationFor_Name_WillFail_WhenName_IsOver250Characters()
+    {
+        _model.Name = new string('x', 251);
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(
+            nameof(EditFactionModel.Name),
+            "Name cannot exceed 250 characters."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_Name_WillFail_WhenName_IsADuplicateName()
+    {
+        A.CallTo(() => _factionRepository.HasDuplicateName(_model.Name, _model.Id)).Returns(true);
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(
+            nameof(CreateFactionModel.Name),
+            "This name already exists."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_Background_WillFail_WhenBackground_IsEmpty()
+    {
+        _model.Background = string.Empty;
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(
+            nameof(EditFactionModel.Background),
+            "Background is required."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_Background_WillFail_WhenBackground_IsOver20000Characters()
+    {
+        _model.Background = new string('x', 20001);
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(
+            nameof(EditFactionModel.Background),
+            "Background cannot exceed 20000 characters."
+        );
+    }
+
+
+    [Fact]
+    public async Task UseCase_WillGrab_TheFaction()
+    {
+        await _useCase.ExecuteAsync(_model);
+        A.CallTo(() => _factionRepository.GetFactionForEditingAsync(_model.Id))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_PassesThrough_TheDbFaction()
+    {
+        await _useCase.ExecuteAsync(_model);
+        A.CallTo(() => _factionRepository.EditFactionAsync(A<Faction>.That.IsSameAs(_dbModel)))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillEditTheFaction()
+    {
+        var faction = new Faction()
+        {
+            Name = _model.Name,
+            Background = _model.Background
+        };
+
+        await _useCase.ExecuteAsync(_model);
+        A.CallTo(() =>
+                _factionRepository.EditFactionAsync(
+                    A<Faction>.That.Matches(k =>
+                        k.Name == faction.Name
+                        && k.Background == faction.Background
+                    )
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/EditFactionUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/EditFactionUseCaseTests.cs
@@ -21,7 +21,7 @@ public class EditFactionUseCaseTests
         {
             Id = 1,
             Name = "parse",
-            Background = "View"
+            Background = "View",
         };
 
         _dbModel = new Faction()
@@ -115,7 +115,6 @@ public class EditFactionUseCaseTests
         );
     }
 
-
     [Fact]
     public async Task UseCase_WillGrab_TheFaction()
     {
@@ -135,18 +134,13 @@ public class EditFactionUseCaseTests
     [Fact]
     public async Task UseCase_WillEditTheFaction()
     {
-        var faction = new Faction()
-        {
-            Name = _model.Name,
-            Background = _model.Background
-        };
+        var faction = new Faction() { Name = _model.Name, Background = _model.Background };
 
         await _useCase.ExecuteAsync(_model);
         A.CallTo(() =>
                 _factionRepository.EditFactionAsync(
                     A<Faction>.That.Matches(k =>
-                        k.Name == faction.Name
-                        && k.Background == faction.Background
+                        k.Name == faction.Name && k.Background == faction.Background
                     )
                 )
             )

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionUseCaseTests.cs
@@ -1,0 +1,70 @@
+using ExpressedRealms.DB.Models.Factions.FactionModels;
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFaction;
+using ExpressedRealms.Shared.UseCases.Tests.Unit;
+using FakeItEasy;
+using Xunit;
+
+namespace ExpressedRealms.Expressions.UseCases.Tests.Unit.Factions;
+
+public class GetFactionUseCaseTests
+{
+    private readonly GetFactionUseCase _useCase;
+    private readonly IFactionRepository _factionRepository;
+    private readonly GetFactionModel _model;
+
+    private Faction FactionDbModel { get; set; }
+
+    public GetFactionUseCaseTests()
+    {
+        _model = new GetFactionModel() { Id = 4 };
+        FactionDbModel = new Faction()
+        {
+            Name = "parse",
+            Background = "View",
+            ExpressionId = 1,
+        };
+
+        _factionRepository = A.Fake<IFactionRepository>();
+
+        A.CallTo(() => _factionRepository.GetFactionAsync(_model.Id)).Returns(FactionDbModel);
+
+        var validator = new GetFactionModelValidator(_factionRepository);
+
+        _useCase = new GetFactionUseCase(_factionRepository, validator, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ValidationFor_Id_WillFail_WhenId_IsEmpty()
+    {
+        _model.Id = 0;
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(nameof(GetFactionModel.Id), "Id is required.");
+    }
+
+    [Fact]
+    public async Task ValidationFor_Id_WillFail_WhenFactionDoesNotExist()
+    {
+        A.CallTo(() => _factionRepository.GetFactionAsync(_model.Id))!
+            .Returns(Task.FromResult((Faction)null!));
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveNotFoundError(nameof(GetFactionModel.Id), "This Faction was not found.");
+    }
+
+    [Fact]
+    public async Task UseCase_Grabs_TheFaction()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _factionRepository.GetFactionAsync(_model.Id)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_Returns_AllPropertiesForTheFaction()
+    {
+        var results = await _useCase.ExecuteAsync(_model);
+
+        Assert.Equal(FactionDbModel.Name, results.Value.Name);
+        Assert.Equal(FactionDbModel.Background, results.Value.Background);
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionsUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionsUseCaseTests.cs
@@ -1,0 +1,92 @@
+using ExpressedRealms.DB.Models.Factions.FactionModels;
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
+using ExpressedRealms.Shared.UseCases.Tests.Unit;
+using FakeItEasy;
+using Xunit;
+
+namespace ExpressedRealms.Expressions.UseCases.Tests.Unit.Factions;
+
+public class GetFactionsUseCaseTests
+{
+    private readonly GetFactionsUseCase _useCase;
+    private readonly IFactionRepository _factionRepository;
+    
+    private readonly GetFactionsModel _model;
+
+    public GetFactionsUseCaseTests()
+    {
+        _factionRepository = A.Fake<IFactionRepository>();
+
+        _model = new GetFactionsModel()
+        {
+            ExpressionId = 1
+        };
+        
+        var validator = new GetFactionsModelValidator();
+
+        _useCase = new GetFactionsUseCase(_factionRepository, validator, CancellationToken.None);
+    }
+    
+    [Fact]
+    public async Task ValidationFor_ExpressionId_WillFail_WhenItIsEmpty()
+    {
+        _model.ExpressionId = 0;
+
+        var results = await _useCase.ExecuteAsync(_model);
+        results.MustHaveValidationError(nameof(GetFactionsModel.ExpressionId), "Expression Id is required.");
+    }
+
+    [Fact]
+    public async Task UseCase_Grabs_TheFactions()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _factionRepository.GetFactions(_model.ExpressionId)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_Returns_ListOfFactions()
+    {
+        var listTest = new List<Faction>()
+        {
+            new()
+            {
+                Id = 1,
+                Name = "Washington",
+                Background = "Money Market Account",
+            },
+            new()
+            {
+                Id = 2,
+                Name = "Human",
+                Background = "Norwegian Krone",
+            },
+        };
+
+        var expectedReturn = new FactionsReturnModel()
+        {
+            Factions = new List<FactionModel>()
+            {
+                new()
+                {
+                    Id = 1,
+                    Name = "Washington",
+                    Background = "Money Market Account",
+                },
+                new()
+                {
+                    Id = 2,
+                    Name = "Human",
+                    Background = "Norwegian Krone",
+                },
+            },
+        };
+
+        A.CallTo(() => _factionRepository.GetFactions(_model.ExpressionId)).Returns(listTest);
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        Assert.Equivalent(expectedReturn.Factions, results.Value.Factions);
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionsUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionsUseCaseTests.cs
@@ -11,30 +11,30 @@ public class GetFactionsUseCaseTests
 {
     private readonly GetFactionsUseCase _useCase;
     private readonly IFactionRepository _factionRepository;
-    
+
     private readonly GetFactionsModel _model;
 
     public GetFactionsUseCaseTests()
     {
         _factionRepository = A.Fake<IFactionRepository>();
 
-        _model = new GetFactionsModel()
-        {
-            ExpressionId = 1
-        };
-        
+        _model = new GetFactionsModel() { ExpressionId = 1 };
+
         var validator = new GetFactionsModelValidator();
 
         _useCase = new GetFactionsUseCase(_factionRepository, validator, CancellationToken.None);
     }
-    
+
     [Fact]
     public async Task ValidationFor_ExpressionId_WillFail_WhenItIsEmpty()
     {
         _model.ExpressionId = 0;
 
         var results = await _useCase.ExecuteAsync(_model);
-        results.MustHaveValidationError(nameof(GetFactionsModel.ExpressionId), "Expression Id is required.");
+        results.MustHaveValidationError(
+            nameof(GetFactionsModel.ExpressionId),
+            "Expression Id is required."
+        );
     }
 
     [Fact]
@@ -42,7 +42,8 @@ public class GetFactionsUseCaseTests
     {
         await _useCase.ExecuteAsync(_model);
 
-        A.CallTo(() => _factionRepository.GetFactions(_model.ExpressionId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _factionRepository.GetFactions(_model.ExpressionId))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Fact]

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/CreateFactionModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/CreateFactionModel.cs
@@ -1,0 +1,8 @@
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.CreateFaction;
+
+public class CreateFactionModel
+{
+    public required string Name { get; set; }
+    public required string Background { get; set; }
+    public required int ExpressionId { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/CreateFactionModelValidator.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/CreateFactionModelValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using JetBrains.Annotations;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.CreateFaction;
+
+[UsedImplicitly]
+internal sealed class CreateFactionModelValidator : AbstractValidator<CreateFactionModel>
+{
+    public CreateFactionModelValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .WithMessage("Name is required.")
+            .MaximumLength(250)
+            .WithMessage("Name cannot exceed 250 characters.");
+
+        RuleFor(x => x.Background)
+            .NotEmpty()
+            .WithMessage("Background is required.")
+            .MaximumLength(20000)
+            .WithMessage("Background cannot exceed 20000 characters.");
+
+        RuleFor(x => x.ExpressionId).NotEmpty().WithMessage("Expression Id is required.");
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/CreateFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/CreateFactionUseCase.cs
@@ -1,0 +1,46 @@
+using ExpressedRealms.DB.Models.Factions.FactionModels;
+using ExpressedRealms.Expressions.Repository.Expressions;
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.UseCases.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.CreateFaction;
+
+internal sealed class CreateFactionUseCase(
+    IFactionRepository factionRepository,
+    IExpressionRepository expressionRepository,
+    CreateFactionModelValidator validator,
+    CancellationToken cancellationToken
+) : ICreateFactionUseCase
+{
+    public async Task<Result<int>> ExecuteAsync(CreateFactionModel model)
+    {
+        var result = await ValidationHelper.ValidateAndHandleErrorsAsync(
+            validator,
+            model,
+            cancellationToken
+        );
+
+        if (result.IsFailed)
+            return Result.Fail(result.Errors);
+        
+        var isExpressionType = await expressionRepository.ExpressionIsExpressionType(model.ExpressionId);
+        if (!isExpressionType)
+            return ValidationHelper.AddSingleValidationFailure(nameof(model.ExpressionId), "Expression Id is not of an expression type.");
+        
+        var isDuplicateName = await factionRepository.HasDuplicateName(model.Name);
+        if (isDuplicateName)
+            return ValidationHelper.AddSingleValidationFailure(nameof(model.Name), "This name already exists.");
+
+        var factionId = await factionRepository.CreateFactionAsync(
+            new Faction()
+            {
+                Name = model.Name,
+                Background = model.Background,
+                ExpressionId = model.ExpressionId,
+            }
+        );
+
+        return Result.Ok(factionId);
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/CreateFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/CreateFactionUseCase.cs
@@ -23,14 +23,22 @@ internal sealed class CreateFactionUseCase(
 
         if (result.IsFailed)
             return Result.Fail(result.Errors);
-        
-        var isExpressionType = await expressionRepository.ExpressionIsExpressionType(model.ExpressionId);
+
+        var isExpressionType = await expressionRepository.ExpressionIsExpressionType(
+            model.ExpressionId
+        );
         if (!isExpressionType)
-            return ValidationHelper.AddSingleValidationFailure(nameof(model.ExpressionId), "Expression Id is not of an expression type.");
-        
+            return ValidationHelper.AddSingleValidationFailure(
+                nameof(model.ExpressionId),
+                "Expression Id is not of an expression type."
+            );
+
         var isDuplicateName = await factionRepository.HasDuplicateName(model.Name);
         if (isDuplicateName)
-            return ValidationHelper.AddSingleValidationFailure(nameof(model.Name), "This name already exists.");
+            return ValidationHelper.AddSingleValidationFailure(
+                nameof(model.Name),
+                "This name already exists."
+            );
 
         var factionId = await factionRepository.CreateFactionAsync(
             new Faction()

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/ICreateFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/CreateFaction/ICreateFactionUseCase.cs
@@ -1,0 +1,6 @@
+using ExpressedRealms.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.CreateFaction;
+
+public interface ICreateFactionUseCase : IGenericUseCase<Result<int>, CreateFactionModel> { }

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/DeleteFactionModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/DeleteFactionModel.cs
@@ -1,0 +1,6 @@
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.DeleteFaction;
+
+public class DeleteFactionModel
+{
+    public int Id { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/DeleteFactionModelValidator.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/DeleteFactionModelValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using JetBrains.Annotations;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.DeleteFaction;
+
+[UsedImplicitly]
+internal sealed class DeleteFactionModelValidator : AbstractValidator<DeleteFactionModel>
+{
+    public DeleteFactionModelValidator()
+    {
+        RuleFor(x => x.Id).NotEmpty().WithMessage("Id is required.");
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/DeleteFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/DeleteFactionUseCase.cs
@@ -1,0 +1,41 @@
+using ExpressedRealms.DB.Interceptors;
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.UseCases.Shared;
+using ExpressedRealms.UseCases.Shared.CommonFailureTypes;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.DeleteFaction;
+
+internal sealed class DeleteFactionUseCase(
+    IFactionRepository factionRepository,
+    DeleteFactionModelValidator validator,
+    CancellationToken cancellationToken
+) : IDeleteFactionUseCase
+{
+    public async Task<Result> ExecuteAsync(DeleteFactionModel model)
+    {
+        var result = await ValidationHelper.ValidateAndHandleErrorsAsync(
+            validator,
+            model,
+            cancellationToken
+        );
+
+        if (result.IsFailed)
+            return Result.Fail(result.Errors);
+        
+        var faction = await factionRepository.GetFactionForEditingAsync(model.Id);
+        
+        if (faction is null)
+        {
+            return Result.Fail(
+                new NotFoundFailure(nameof(DeleteFactionModel.Id), "This Faction was not found.")
+            );
+        }
+
+        faction.SoftDelete();
+
+        await factionRepository.EditFactionAsync(faction);
+
+        return Result.Ok();
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/DeleteFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/DeleteFactionUseCase.cs
@@ -22,9 +22,9 @@ internal sealed class DeleteFactionUseCase(
 
         if (result.IsFailed)
             return Result.Fail(result.Errors);
-        
+
         var faction = await factionRepository.GetFactionForEditingAsync(model.Id);
-        
+
         if (faction is null)
         {
             return Result.Fail(

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/IDeleteFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/DeleteFaction/IDeleteFactionUseCase.cs
@@ -1,0 +1,6 @@
+using ExpressedRealms.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.DeleteFaction;
+
+public interface IDeleteFactionUseCase : IGenericUseCase<Result, DeleteFactionModel> { }

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/EditFactionModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/EditFactionModel.cs
@@ -1,0 +1,8 @@
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.EditFaction;
+
+public class EditFactionModel
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public required string Background { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/EditFactionModelValidator.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/EditFactionModelValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using JetBrains.Annotations;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.EditFaction;
+
+[UsedImplicitly]
+internal sealed class EditFactionModelValidator : AbstractValidator<EditFactionModel>
+{
+    public EditFactionModelValidator()
+    {
+        RuleFor(x => x.Id).NotEmpty().WithMessage("Id is required.");
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .WithMessage("Name is required.")
+            .MaximumLength(250)
+            .WithMessage("Name cannot exceed 250 characters.");
+
+        RuleFor(x => x.Background)
+            .NotEmpty()
+            .WithMessage("Background is required.")
+            .MaximumLength(20000)
+            .WithMessage("Background cannot exceed 20000 characters.");
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/EditFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/EditFactionUseCase.cs
@@ -1,0 +1,45 @@
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.UseCases.Shared;
+using ExpressedRealms.UseCases.Shared.CommonFailureTypes;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.EditFaction;
+
+internal sealed class EditFactionUseCase(
+    IFactionRepository factionRepository,
+    EditFactionModelValidator validator,
+    CancellationToken cancellationToken
+) : IEditFactionUseCase
+{
+    public async Task<Result> ExecuteAsync(EditFactionModel model)
+    {
+        var result = await ValidationHelper.ValidateAndHandleErrorsAsync(
+            validator,
+            model,
+            cancellationToken
+        );
+
+        if (result.IsFailed)
+            return Result.Fail(result.Errors);
+
+        var faction = await factionRepository.GetFactionForEditingAsync(model.Id);
+        
+        if (faction is null)
+        {
+            return Result.Fail(
+                new NotFoundFailure(nameof(EditFactionModel.Id), "This Faction was not found.")
+            );
+        }
+        
+        var isDuplicateName = await factionRepository.HasDuplicateName(model.Name, model.Id);
+        if (isDuplicateName)
+            return ValidationHelper.AddSingleValidationFailure(nameof(model.Name), "This name already exists.");
+        
+        faction.Name = model.Name;
+        faction.Background = model.Background;
+
+        await factionRepository.EditFactionAsync(faction);
+
+        return Result.Ok();
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/EditFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/EditFactionUseCase.cs
@@ -23,18 +23,21 @@ internal sealed class EditFactionUseCase(
             return Result.Fail(result.Errors);
 
         var faction = await factionRepository.GetFactionForEditingAsync(model.Id);
-        
+
         if (faction is null)
         {
             return Result.Fail(
                 new NotFoundFailure(nameof(EditFactionModel.Id), "This Faction was not found.")
             );
         }
-        
+
         var isDuplicateName = await factionRepository.HasDuplicateName(model.Name, model.Id);
         if (isDuplicateName)
-            return ValidationHelper.AddSingleValidationFailure(nameof(model.Name), "This name already exists.");
-        
+            return ValidationHelper.AddSingleValidationFailure(
+                nameof(model.Name),
+                "This name already exists."
+            );
+
         faction.Name = model.Name;
         faction.Background = model.Background;
 

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/IEditFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/EditFaction/IEditFactionUseCase.cs
@@ -1,0 +1,6 @@
+using ExpressedRealms.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.EditFaction;
+
+public interface IEditFactionUseCase : IGenericUseCase<Result, EditFactionModel> { }

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionModel.cs
@@ -1,0 +1,6 @@
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFaction;
+
+public class GetFactionModel
+{
+    public int Id { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionModelValidator.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionModelValidator.cs
@@ -1,0 +1,14 @@
+using ExpressedRealms.Expressions.Repository.Factions;
+using FluentValidation;
+using JetBrains.Annotations;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFaction;
+
+[UsedImplicitly]
+internal sealed class GetFactionModelValidator : AbstractValidator<GetFactionModel>
+{
+    public GetFactionModelValidator(IFactionRepository repository)
+    {
+        RuleFor(x => x.Id).NotEmpty().WithMessage("Id is required.");
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionReturnModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionReturnModel.cs
@@ -1,0 +1,8 @@
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFaction;
+
+public class GetFactionReturnModel
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public required string Background { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionUseCase.cs
@@ -36,7 +36,7 @@ internal sealed class GetFactionUseCase(
             {
                 Id = faction.Id,
                 Name = faction.Name,
-                Background = faction.Background
+                Background = faction.Background,
             }
         );
     }

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/GetFactionUseCase.cs
@@ -1,0 +1,43 @@
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.UseCases.Shared;
+using ExpressedRealms.UseCases.Shared.CommonFailureTypes;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFaction;
+
+internal sealed class GetFactionUseCase(
+    IFactionRepository factionRepository,
+    GetFactionModelValidator validator,
+    CancellationToken cancellationToken
+) : IGetFactionUseCase
+{
+    public async Task<Result<GetFactionReturnModel>> ExecuteAsync(GetFactionModel model)
+    {
+        var result = await ValidationHelper.ValidateAndHandleErrorsAsync(
+            validator,
+            model,
+            cancellationToken
+        );
+
+        if (result.IsFailed)
+            return Result.Fail(result.Errors);
+
+        var faction = await factionRepository.GetFactionAsync(model.Id);
+
+        if (faction is null)
+        {
+            return Result.Fail(
+                new NotFoundFailure(nameof(GetFactionModel.Id), "This Faction was not found.")
+            );
+        }
+
+        return Result.Ok(
+            new GetFactionReturnModel()
+            {
+                Id = faction.Id,
+                Name = faction.Name,
+                Background = faction.Background
+            }
+        );
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/IGetFactionUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFaction/IGetFactionUseCase.cs
@@ -1,0 +1,7 @@
+using ExpressedRealms.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFaction;
+
+public interface IGetFactionUseCase
+    : IGenericUseCase<Result<GetFactionReturnModel>, GetFactionModel> { }

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/FactionModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/FactionModel.cs
@@ -1,0 +1,8 @@
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
+
+public class FactionModel
+{
+    public int Id { get; set; }
+    public required string Name { get; set; }
+    public required string Background { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/FactionsReturnModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/FactionsReturnModel.cs
@@ -1,0 +1,6 @@
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
+
+public class FactionsReturnModel
+{
+    public List<FactionModel> Factions { get; set; } = new();
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsModel.cs
@@ -1,0 +1,6 @@
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
+
+public class GetFactionsModel
+{
+    public int ExpressionId { get; set; }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsModelValidator.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsModelValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using JetBrains.Annotations;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
+
+[UsedImplicitly]
+internal sealed class GetFactionsModelValidator : AbstractValidator<GetFactionsModel>
+{
+    public GetFactionsModelValidator()
+    {
+        RuleFor(x => x.ExpressionId).NotEmpty().WithMessage("Expression Id is required.");
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsUseCase.cs
@@ -17,10 +17,10 @@ internal sealed class GetFactionsUseCase(
             model,
             cancellationToken
         );
-        
+
         if (result.IsFailed)
             return Result.Fail(result.Errors);
-        
+
         var factions = await factionRepository.GetFactions(model.ExpressionId);
 
         return Result.Ok(

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsUseCase.cs
@@ -1,0 +1,40 @@
+using ExpressedRealms.Expressions.Repository.Factions;
+using ExpressedRealms.UseCases.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
+
+internal sealed class GetFactionsUseCase(
+    IFactionRepository factionRepository,
+    GetFactionsModelValidator validator,
+    CancellationToken cancellationToken
+) : IGetFactionsUseCase
+{
+    public async Task<Result<FactionsReturnModel>> ExecuteAsync(GetFactionsModel model)
+    {
+        var result = await ValidationHelper.ValidateAndHandleErrorsAsync(
+            validator,
+            model,
+            cancellationToken
+        );
+        
+        if (result.IsFailed)
+            return Result.Fail(result.Errors);
+        
+        var factions = await factionRepository.GetFactions(model.ExpressionId);
+
+        return Result.Ok(
+            new FactionsReturnModel()
+            {
+                Factions = factions
+                    .Select(x => new FactionModel()
+                    {
+                        Id = x.Id,
+                        Name = x.Name,
+                        Background = x.Background,
+                    })
+                    .ToList(),
+            }
+        );
+    }
+}

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/IGetFactionsUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/IGetFactionsUseCase.cs
@@ -1,0 +1,6 @@
+using ExpressedRealms.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
+
+public interface IGetFactionsUseCase : IGenericUseCase<Result<FactionsReturnModel>, GetFactionsModel> { }

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/IGetFactionsUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/IGetFactionsUseCase.cs
@@ -3,4 +3,5 @@ using FluentResults;
 
 namespace ExpressedRealms.Expressions.UseCases.FactionUseCases.GetFactions;
 
-public interface IGetFactionsUseCase : IGenericUseCase<Result<FactionsReturnModel>, GetFactionsModel> { }
+public interface IGetFactionsUseCase
+    : IGenericUseCase<Result<FactionsReturnModel>, GetFactionsModel> { }

--- a/api/ExpressedRealms.Scaffolder/Generator/Generator.cs
+++ b/api/ExpressedRealms.Scaffolder/Generator/Generator.cs
@@ -30,7 +30,7 @@ public static class CrudGenerator
         var templateRoot = GetTemplateLocation("EntitiesUseCaseTests");
         Generate(model, templateRoot, $"{model.Plural}");
     }
-    
+
     private static string GetTemplateLocation(string folder)
     {
         return Path.Combine(AppContext.BaseDirectory, "Templates", folder);

--- a/api/ExpressedRealms.Scaffolder/Generator/Renderers/ValidationRenderer.cs
+++ b/api/ExpressedRealms.Scaffolder/Generator/Renderers/ValidationRenderer.cs
@@ -17,7 +17,7 @@ public static class ValidationRenderer
 
                     var propertyDefinitions =
                         properties as PropertyDefinition[] ?? properties.ToArray();
-                    
+
                     foreach (var property in propertyDefinitions)
                     {
                         sb.Append($"RuleFor(x => x.{property.Name})");
@@ -40,12 +40,17 @@ public static class ValidationRenderer
 
     private static void HandleMinLengthValidation(PropertyDefinition property, StringBuilder sb)
     {
-        if (property.MinValue == null) return;
-        
-        sb.Append(
-            $"{Environment.NewLine}    .MinimumLength({property.MinValue})"
-        );
-        if (string.Equals(property.Type.ToLowerInvariant(), "string", StringComparison.InvariantCultureIgnoreCase))
+        if (property.MinValue == null)
+            return;
+
+        sb.Append($"{Environment.NewLine}    .MinimumLength({property.MinValue})");
+        if (
+            string.Equals(
+                property.Type.ToLowerInvariant(),
+                "string",
+                StringComparison.InvariantCultureIgnoreCase
+            )
+        )
         {
             sb.Append(
                 $"{Environment.NewLine}    .WithMessage(\"{property.Name} cannot be below {property.MinValue} characters.\")"
@@ -61,12 +66,17 @@ public static class ValidationRenderer
 
     private static void HandleMaxLengthValidation(PropertyDefinition property, StringBuilder sb)
     {
-        if (property.MaxValue == null) return;
-        
-        sb.Append(
-            $"{Environment.NewLine}    .MaximumLength({property.MaxValue})"
-        );
-        if (string.Equals(property.Type.ToLowerInvariant(), "string", StringComparison.InvariantCultureIgnoreCase))
+        if (property.MaxValue == null)
+            return;
+
+        sb.Append($"{Environment.NewLine}    .MaximumLength({property.MaxValue})");
+        if (
+            string.Equals(
+                property.Type.ToLowerInvariant(),
+                "string",
+                StringComparison.InvariantCultureIgnoreCase
+            )
+        )
         {
             sb.Append(
                 $"{Environment.NewLine}    .WithMessage(\"{property.Name} cannot exceed {property.MaxValue} characters.\")"
@@ -82,12 +92,10 @@ public static class ValidationRenderer
 
     private static void HandleRequiredValidation(PropertyDefinition property, StringBuilder sb)
     {
-        if (!property.Required) return;
-        
+        if (!property.Required)
+            return;
+
         sb.Append($"{Environment.NewLine}    .NotEmpty()");
-        sb.Append(
-            $"{Environment.NewLine}    .WithMessage(\"{property.Name} is required.\")"
-        );
+        sb.Append($"{Environment.NewLine}    .WithMessage(\"{property.Name} is required.\")");
     }
-    
 }

--- a/api/ExpressedRealms.Scaffolder/Generator/Renderers/ValidationTestsRenderer.cs
+++ b/api/ExpressedRealms.Scaffolder/Generator/Renderers/ValidationTestsRenderer.cs
@@ -43,7 +43,7 @@ public static class ValidationTestsRenderer
         sb.AppendLine(
             $$"""
               [Fact]
-              public async Task ValidationFor_{{property.Name}}_WillFail_When{{property.Name}}_IsEmpty()
+              public async Task ValidationFor_{{property.Name}}_WillFail_WhenItIsEmpty()
               {
                   _model.{{property.Name}} = {{emptyValue}};
 

--- a/api/ExpressedRealms.Scaffolder/Generator/Renderers/ValidationTestsRenderer.cs
+++ b/api/ExpressedRealms.Scaffolder/Generator/Renderers/ValidationTestsRenderer.cs
@@ -34,28 +34,36 @@ public static class ValidationTestsRenderer
         );
     }
 
-    private static void HandleRequiredTest(PropertyDefinition property, StringBuilder sb, string targetModel,
-        PropertyDefinition[] propertyDefinitions)
+    private static void HandleRequiredTest(
+        PropertyDefinition property,
+        StringBuilder sb,
+        string targetModel,
+        PropertyDefinition[] propertyDefinitions
+    )
     {
-        if (!property.Required) return;
-        
-        var emptyValue = string.Equals(property.Type, "string", StringComparison.InvariantCultureIgnoreCase) ? "string.Empty" : "default";
+        if (!property.Required)
+            return;
+
+        var emptyValue = string.Equals(
+            property.Type,
+            "string",
+            StringComparison.InvariantCultureIgnoreCase
+        )
+            ? "string.Empty"
+            : "default";
         sb.AppendLine(
             $$"""
-              [Fact]
-              public async Task ValidationFor_{{property.Name}}_WillFail_WhenItIsEmpty()
-              {
-                  _model.{{property.Name}} = {{emptyValue}};
+            [Fact]
+            public async Task ValidationFor_{{property.Name}}_WillFail_WhenItIsEmpty()
+            {
+                _model.{{property.Name}} = {{emptyValue}};
 
-                  var results = await _useCase.ExecuteAsync(_model);
-                  results.MustHaveValidationError(nameof({{targetModel}}.{{property.Name}}), "{{property.Name}} is required.");
-              }
-              """
+                var results = await _useCase.ExecuteAsync(_model);
+                results.MustHaveValidationError(nameof({{targetModel}}.{{property.Name}}), "{{property.Name}} is required.");
+            }
+            """
         );
-        if (
-            propertyDefinitions.IndexOf(property)
-            != propertyDefinitions.Length - 1
-        )
+        if (propertyDefinitions.IndexOf(property) != propertyDefinitions.Length - 1)
             sb.AppendLine();
     }
 
@@ -66,8 +74,9 @@ public static class ValidationTestsRenderer
         PropertyDefinition[] propertyDefinitions
     )
     {
-        if (property.MaxValue is null) return;
-        
+        if (property.MaxValue is null)
+            return;
+
         if (string.Equals(property.Type, "string", StringComparison.InvariantCultureIgnoreCase))
         {
             sb.AppendLine(
@@ -103,38 +112,43 @@ public static class ValidationTestsRenderer
             sb.AppendLine();
     }
 
-    private static void HandleMinValidationTestss(PropertyDefinition property, StringBuilder sb, string targetModel,
-        PropertyDefinition[] propertyDefinitions)
+    private static void HandleMinValidationTestss(
+        PropertyDefinition property,
+        StringBuilder sb,
+        string targetModel,
+        PropertyDefinition[] propertyDefinitions
+    )
     {
-        if (property.MinValue is null) return;
+        if (property.MinValue is null)
+            return;
         if (string.Equals(property.Type, "string", StringComparison.InvariantCultureIgnoreCase))
         {
             sb.AppendLine(
                 $$"""
-                  [Fact]
-                  public async Task ValidationFor_{{property.Name}}_WillFail_When{{property.Name}}_IsUnder{{property.MinValue}}Characters()
-                  {
-                      _model.{{property.Name}} = new string('x', {{property.MinValue - 1}});
+                [Fact]
+                public async Task ValidationFor_{{property.Name}}_WillFail_When{{property.Name}}_IsUnder{{property.MinValue}}Characters()
+                {
+                    _model.{{property.Name}} = new string('x', {{property.MinValue - 1}});
 
-                      var results = await _useCase.ExecuteAsync(_model);
-                      results.MustHaveValidationError(nameof({{targetModel}}.{{property.Name}}), "{{property.Name}} cannot be below {{property.MinValue}} characters.");
-                  }
-                  """
+                    var results = await _useCase.ExecuteAsync(_model);
+                    results.MustHaveValidationError(nameof({{targetModel}}.{{property.Name}}), "{{property.Name}} cannot be below {{property.MinValue}} characters.");
+                }
+                """
             );
         }
         else
         {
             sb.AppendLine(
                 $$"""
-                  [Fact]
-                  public async Task ValidationFor_{{property.Name}}_WillFail_When{{property.Name}}_IsUnder{{property.MinValue}}()
-                  {
-                      _model.{{property.Name}} = {{property.MinValue - 1}};
+                [Fact]
+                public async Task ValidationFor_{{property.Name}}_WillFail_When{{property.Name}}_IsUnder{{property.MinValue}}()
+                {
+                    _model.{{property.Name}} = {{property.MinValue - 1}};
 
-                      var results = await _useCase.ExecuteAsync(_model);
-                      results.MustHaveValidationError(nameof({{targetModel}}.{{property.Name}}), "{{property.Name}} cannot be below {{property.MinValue}}.");
-                  }
-                  """
+                    var results = await _useCase.ExecuteAsync(_model);
+                    results.MustHaveValidationError(nameof({{targetModel}}.{{property.Name}}), "{{property.Name}} cannot be below {{property.MinValue}}.");
+                }
+                """
             );
         }
         if (propertyDefinitions.IndexOf(property) != propertyDefinitions.Length - 1)

--- a/api/ExpressedRealms.Scaffolder/SubCommands/CommonArguments.cs
+++ b/api/ExpressedRealms.Scaffolder/SubCommands/CommonArguments.cs
@@ -71,7 +71,9 @@ internal class CommonArguments
         };
     }
 
-    private static List<PropertyDefinition> GetAdditionalProperties(string? additionalPropertiesArgValue)
+    private static List<PropertyDefinition> GetAdditionalProperties(
+        string? additionalPropertiesArgValue
+    )
     {
         var additionalProperties = new List<PropertyDefinition>();
 

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/CreateEntityUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/CreateEntityUseCaseTests.sbn
@@ -10,7 +10,7 @@ namespace ExpressedRealms.{{ projectname }}.UseCases.Tests.Unit.{{ plural }};
 public class Create{{ singular }}UseCaseTests
 {
     private readonly Create{{ singular }}UseCase _useCase;
-    private readonly I{{ singular }}Repository _repository;
+    private readonly I{{ singular }}Repository _{{singular | string.downcase}}Repository;
     private readonly Create{{ singular }}Model _model;
 
     public Create{{ singular }}UseCaseTests()
@@ -20,11 +20,11 @@ public class Create{{ singular }}UseCaseTests
             {{ render_unit_test_assignment_properties properties "x" ~}}
         };
 
-        _repository = A.Fake<I{{ singular }}Repository>();
+        _{{singular | string.downcase}}repository = A.Fake<I{{ singular }}Repository>();
 
         var validator = new Create{{ singular }}ModelValidator();
 
-        _useCase = new Create{{ singular }}UseCase(_repository, validator, CancellationToken.None);
+        _useCase = new Create{{ singular }}UseCase(_{{singular | string.downcase}}Repository, validator, CancellationToken.None);
     }
 
     {{ validation_property_tests properties $"Create{singular}Model" ~}}
@@ -39,7 +39,7 @@ public class Create{{ singular }}UseCaseTests
 
         await _useCase.ExecuteAsync(_model);
         A.CallTo(() =>
-                _repository.Create{{ singular }}Async(
+                _{{singular | string.downcase}}Repository.Create{{ singular }}Async(
                     A<{{ singular }}>.That.Matches(k =>
                         {{ render_unit_test_check_properties properties "k" (singular | string.downcase) ~}}
                     )
@@ -51,7 +51,7 @@ public class Create{{ singular }}UseCaseTests
     [Fact]
     public async Task UseCase_WillReturn_{{ singular }}Id_IfSuccessful()
     {
-        A.CallTo(() => _repository.Create{{ singular }}Async(A<{{ singular }}>._)).Returns(5);
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Create{{ singular }}Async(A<{{ singular }}>._)).Returns(5);
 
         var result = await _useCase.ExecuteAsync(_model);
         Assert.Equal(5, result.Value);

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/CreateEntityUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/CreateEntityUseCaseTests.sbn
@@ -22,7 +22,7 @@ public class Create{{ singular }}UseCaseTests
 
         _repository = A.Fake<I{{ singular }}Repository>();
 
-        var validator = new Create{{ singular }}ModelValidator(_repository);
+        var validator = new Create{{ singular }}ModelValidator();
 
         _useCase = new Create{{ singular }}UseCase(_repository, validator, CancellationToken.None);
     }

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/DeleteEntityUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/DeleteEntityUseCaseTests.sbn
@@ -22,7 +22,7 @@ public class Delete{{ singular }}UseCaseTests
         A.CallTo(() => _repository.Get{{ singular }}ForEditingAsync(_model.Id))
             .Returns(new {{ singular }}() { Id = _model.Id });
 
-        var validator = new Delete{{ singular }}ModelValidator(_repository);
+        var validator = new Delete{{ singular }}ModelValidator();
 
         _useCase = new Delete{{ singular }}UseCase(_repository, validator, CancellationToken.None);
     }

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/DeleteEntityUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/DeleteEntityUseCaseTests.sbn
@@ -10,21 +10,21 @@ namespace ExpressedRealms.{{ projectname }}.UseCases.Tests.Unit.{{ plural }};
 public class Delete{{ singular }}UseCaseTests
 {
     private readonly Delete{{ singular }}UseCase _useCase;
-    private readonly I{{ singular }}Repository _repository;
+    private readonly I{{ singular }}Repository _{{singular | string.downcase}}Repository;
     private readonly Delete{{ singular }}Model _model;
 
     public Delete{{ singular }}UseCaseTests()
     {
         _model = new Delete{{ singular }}Model() { Id = 4 };
 
-        _repository = A.Fake<I{{ singular }}Repository>();
+        _{{singular | string.downcase}}Repository = A.Fake<I{{ singular }}Repository>();
 
-        A.CallTo(() => _repository.Get{{ singular }}ForEditingAsync(_model.Id))
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}ForEditingAsync(_model.Id))
             .Returns(new {{ singular }}() { Id = _model.Id });
 
         var validator = new Delete{{ singular }}ModelValidator();
 
-        _useCase = new Delete{{ singular }}UseCase(_repository, validator, CancellationToken.None);
+        _useCase = new Delete{{ singular }}UseCase(_{{singular | string.downcase}}Repository, validator, CancellationToken.None);
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class Delete{{ singular }}UseCaseTests
     [Fact]
     public async Task ValidationFor_Id_WillFail_When{{ singular }}DoesNotExist()
     {
-        A.CallTo(() => _repository.Get{{ singular }}ForEditingAsync(_model.Id))!.Returns(Task.FromResult(({{ singular }})null!));
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}ForEditingAsync(_model.Id))!.Returns(Task.FromResult(({{ singular }})null!));
         var results = await _useCase.ExecuteAsync(_model);
         results.MustHaveNotFoundError(nameof(Delete{{ singular }}Model.Id), "This {{ singular }} was not found.");
     }
@@ -48,7 +48,7 @@ public class Delete{{ singular }}UseCaseTests
     {
         await _useCase.ExecuteAsync(_model);
 
-        A.CallTo(() => _repository.Get{{ singular }}ForEditingAsync(_model.Id))
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}ForEditingAsync(_model.Id))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -60,7 +60,7 @@ public class Delete{{ singular }}UseCaseTests
         await _useCase.ExecuteAsync(_model);
 
         A.CallTo(() =>
-                _repository.Edit{{ singular }}Async(
+                _{{singular | string.downcase}}Repository.Edit{{ singular }}Async(
                     A<{{ singular }}>.That.Matches(k =>
                         k.Id == {{ singular | string.downcase }}.Id && k.IsDeleted == {{ singular | string.downcase }}.IsDeleted
                     )

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/EditEntityUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/EditEntityUseCaseTests.sbn
@@ -31,7 +31,7 @@ public class Edit{{ singular }}UseCaseTests
 
         A.CallTo(() => _repository.Get{{ singular }}ForEditingAsync(_model.Id)).Returns(_dbModel);
 
-        var validator = new Edit{{ singular }}ModelValidator(_repository);
+        var validator = new Edit{{ singular }}ModelValidator();
 
         _useCase = new Edit{{ singular }}UseCase(_repository, validator, CancellationToken.None);
     }

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/EditEntityUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/EditEntityUseCaseTests.sbn
@@ -10,7 +10,7 @@ namespace ExpressedRealms.{{ projectname }}.UseCases.Tests.Unit.{{ plural }};
 public class Edit{{ singular }}UseCaseTests
 {
     private readonly Edit{{ singular }}UseCase _useCase;
-    private readonly I{{ singular }}Repository _repository;
+    private readonly I{{ singular }}Repository _{{singular | string.downcase}}Repository;
     private readonly Edit{{ singular }}Model _model;
     private readonly {{ singular }} _dbModel;
 
@@ -27,13 +27,13 @@ public class Edit{{ singular }}UseCaseTests
             {{ render_unit_test_assignment_properties properties "x" ~}}
         };
 
-        _repository = A.Fake<I{{ singular }}Repository>();
+        _{{singular | string.downcase}}Repository = A.Fake<I{{ singular }}Repository>();
 
-        A.CallTo(() => _repository.Get{{ singular }}ForEditingAsync(_model.Id)).Returns(_dbModel);
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}ForEditingAsync(_model.Id)).Returns(_dbModel);
 
         var validator = new Edit{{ singular }}ModelValidator();
 
-        _useCase = new Edit{{ singular }}UseCase(_repository, validator, CancellationToken.None);
+        _useCase = new Edit{{ singular }}UseCase(_{{singular | string.downcase}}Repository, validator, CancellationToken.None);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class Edit{{ singular }}UseCaseTests
     [Fact]
     public async Task ValidationFor_Id_WillFail_When{{ singular }}DoesNotExist()
     {
-        A.CallTo(() => _repository.Get{{ singular }}ForEditingAsync(_model.Id))!.Returns(Task.FromResult(({{ singular }})null!));
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}ForEditingAsync(_model.Id))!.Returns(Task.FromResult(({{ singular }})null!));
         var results = await _useCase.ExecuteAsync(_model);
         results.MustHaveNotFoundError(nameof(Edit{{ singular }}Model.Id), "This {{ singular }} was not found.");
     }
@@ -58,7 +58,7 @@ public class Edit{{ singular }}UseCaseTests
     public async Task UseCase_WillGrab_The{{ singular }}()
     {
         await _useCase.ExecuteAsync(_model);
-        A.CallTo(() => _repository.Get{{ singular }}ForEditingAsync(_model.Id))
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}ForEditingAsync(_model.Id))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -66,7 +66,7 @@ public class Edit{{ singular }}UseCaseTests
     public async Task UseCase_PassesThrough_TheDb{{ singular }}()
     {
         await _useCase.ExecuteAsync(_model);
-        A.CallTo(() => _repository.Edit{{ singular }}Async(A<{{ singular }}>.That.IsSameAs(_dbModel)))
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Edit{{ singular }}Async(A<{{ singular }}>.That.IsSameAs(_dbModel)))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -80,7 +80,7 @@ public class Edit{{ singular }}UseCaseTests
 
         await _useCase.ExecuteAsync(_model);
         A.CallTo(() =>
-                _repository.Edit{{ singular }}Async(
+                _{{singular | string.downcase}}Repository.Edit{{ singular }}Async(
                     A<{{ singular }}>.That.Matches(k =>
                         {{ render_unit_test_check_properties properties "k" (singular | string.downcase) ~}}
                     )

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/GetEntitiesUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/GetEntitiesUseCaseTests.sbn
@@ -10,13 +10,13 @@ namespace ExpressedRealms.{{ projectname }}.UseCases.Tests.Unit.{{ plural }};
 public class Get{{ plural }}UseCaseTests
 {
     private readonly Get{{ plural }}UseCase _useCase;
-    private readonly I{{ singular }}Repository _repository;
+    private readonly I{{ singular }}Repository _{{singular | string.downcase}}Repository;
 
     public Get{{ plural }}UseCaseTests()
     {
-        _repository = A.Fake<I{{ singular }}Repository>();
+        _{{singular | string.downcase}}Repository = A.Fake<I{{ singular }}Repository>();
 
-        _useCase = new Get{{ plural }}UseCase(_repository);
+        _useCase = new Get{{ plural }}UseCase(_{{singular | string.downcase}}Repository);
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class Get{{ plural }}UseCaseTests
     {
         await _useCase.ExecuteAsync();
 
-        A.CallTo(() => _repository.Get{{ plural }}()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ plural }}()).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class Get{{ plural }}UseCaseTests
             },
         };
 
-        A.CallTo(() => _repository.Get{{ plural }}()).Returns(listTest);
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ plural }}()).Returns(listTest);
 
         var results = await _useCase.ExecuteAsync();
 

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/GetEntityUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/GetEntityUseCaseTests.sbn
@@ -10,7 +10,7 @@ namespace ExpressedRealms.{{ projectname }}.UseCases.Tests.Unit.{{ plural }};
 public class Get{{ singular }}UseCaseTests
 {
     private readonly Get{{ singular }}UseCase _useCase;
-    private readonly I{{ singular }}Repository _repository;
+    private readonly I{{ singular }}Repository _{{singular | string.downcase}}Repository;
     private readonly Get{{ singular }}Model _model;
 
     private {{ singular }} {{ singular }}DbModel { get; set; }
@@ -23,13 +23,13 @@ public class Get{{ singular }}UseCaseTests
             {{ render_unit_test_assignment_properties properties "x" ~}}
         };
 
-        _repository = A.Fake<I{{ singular }}Repository>();
+        _{{singular | string.downcase}}Repository = A.Fake<I{{ singular }}Repository>();
 
-        A.CallTo(() => _repository.Get{{ singular }}Async(_model.Id)).Returns({{ singular }}DbModel);
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}Async(_model.Id)).Returns({{ singular }}DbModel);
 
         var validator = new Get{{ singular }}ModelValidator();
 
-        _useCase = new Get{{ singular }}UseCase(_repository, validator, CancellationToken.None);
+        _useCase = new Get{{ singular }}UseCase(_{{singular | string.downcase}}Repository, validator, CancellationToken.None);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class Get{{ singular }}UseCaseTests
     [Fact]
     public async Task ValidationFor_Id_WillFail_When{{ singular }}DoesNotExist()
     {
-        A.CallTo(() => _repository.Get{{ singular }}Async(_model.Id))!.Returns(Task.FromResult(({{ singular }})null!));
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}Async(_model.Id))!.Returns(Task.FromResult(({{ singular }})null!));
         var results = await _useCase.ExecuteAsync(_model);
         results.MustHaveNotFoundError(nameof(Get{{ singular }}Model.Id), "This {{ singular }} was not found.");
     }
@@ -53,7 +53,7 @@ public class Get{{ singular }}UseCaseTests
     {
         await _useCase.ExecuteAsync(_model);
 
-        A.CallTo(() => _repository.Get{{ singular }}Async(_model.Id)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _{{singular | string.downcase}}Repository.Get{{ singular }}Async(_model.Id)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]

--- a/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/GetEntityUseCaseTests.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntitiesUseCaseTests/GetEntityUseCaseTests.sbn
@@ -27,7 +27,7 @@ public class Get{{ singular }}UseCaseTests
 
         A.CallTo(() => _repository.Get{{ singular }}Async(_model.Id)).Returns({{ singular }}DbModel);
 
-        var validator = new Get{{ singular }}ModelValidator(_repository);
+        var validator = new Get{{ singular }}ModelValidator();
 
         _useCase = new Get{{ singular }}UseCase(_repository, validator, CancellationToken.None);
     }

--- a/api/ExpressedRealms.Scaffolder/Templates/EntityRepository/EntityRepository.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntityRepository/EntityRepository.sbn
@@ -45,7 +45,7 @@ internal sealed class {{ singular }}Repository(
 
     public async Task<List<{{ singular }}>> Get{{ plural }}()
     {
-        return await context.{{ plural }}
+        return await context.{{ plural }}.AsNoTracking()
             .ToListAsync(cancellationToken);
     }
 

--- a/api/ExpressedRealms.Scaffolder/Templates/EntityUseCases/CreateEntity/CreateEntityModelValidator.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntityUseCases/CreateEntity/CreateEntityModelValidator.sbn
@@ -7,7 +7,7 @@ namespace {{ namespacebase }}.{{ singular }}UseCases.Create{{ singular }};
 [UsedImplicitly]
 internal sealed class Create{{ singular }}ModelValidator : AbstractValidator<Create{{ singular }}Model>
 {
-    public Create{{ singular }}ModelValidator(I{{ singular }}Repository repository)
+    public Create{{ singular }}ModelValidator()
     {
         {{ validation_rule_generator properties ~}}
     }

--- a/api/ExpressedRealms.Scaffolder/Templates/EntityUseCases/DeleteEntity/DeleteEntityModelValidator.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntityUseCases/DeleteEntity/DeleteEntityModelValidator.sbn
@@ -7,7 +7,7 @@ namespace {{ namespacebase }}.{{ singular }}UseCases.Delete{{ singular }};
 [UsedImplicitly]
 internal sealed class Delete{{ singular }}ModelValidator : AbstractValidator<Delete{{ singular }}Model>
 {
-    public Delete{{ singular }}ModelValidator(I{{ singular }}Repository repository)
+    public Delete{{ singular }}ModelValidator()
     {
         RuleFor(x => x.Id)
             .NotEmpty()

--- a/api/ExpressedRealms.Scaffolder/Templates/EntityUseCases/EditEntity/EditEntityModelValidator.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntityUseCases/EditEntity/EditEntityModelValidator.sbn
@@ -7,7 +7,7 @@ namespace {{ namespacebase }}.{{ singular }}UseCases.Edit{{ singular }};
 [UsedImplicitly]
 internal sealed class Edit{{ singular }}ModelValidator : AbstractValidator<Edit{{ singular }}Model>
 {
-    public Edit{{ singular }}ModelValidator(I{{ singular }}Repository repository)
+    public Edit{{ singular }}ModelValidator()
     {
         RuleFor(x => x.Id)
             .NotEmpty()

--- a/api/ExpressedRealms.Scaffolder/Templates/EntityUseCases/GetEntity/GetEntityModelValidator.sbn
+++ b/api/ExpressedRealms.Scaffolder/Templates/EntityUseCases/GetEntity/GetEntityModelValidator.sbn
@@ -7,7 +7,7 @@ namespace {{ namespacebase }}.{{ singular }}UseCases.Get{{ singular }};
 [UsedImplicitly]
 internal sealed class Get{{ singular }}ModelValidator : AbstractValidator<Get{{ singular }}Model>
 {
-    public Get{{ singular }}ModelValidator(I{{ singular }}Repository repository)
+    public Get{{ singular }}ModelValidator()
     {
         RuleFor(x => x.Id)
             .NotEmpty()

--- a/api/ExpressedRealms.Shared.UseCases/ValidationHelper.cs
+++ b/api/ExpressedRealms.Shared.UseCases/ValidationHelper.cs
@@ -61,4 +61,9 @@ public static class ValidationHelper
             ErrorCode = "InvalidIds",
         };
     }
+    
+    public static Result AddSingleValidationFailure(string propertyName, string message)
+    {
+        return Result.Fail(new FluentValidationFailure(new Dictionary<string, string[]> { { propertyName, [message] } }));
+    }
 }

--- a/api/ExpressedRealms.Shared.UseCases/ValidationHelper.cs
+++ b/api/ExpressedRealms.Shared.UseCases/ValidationHelper.cs
@@ -61,9 +61,13 @@ public static class ValidationHelper
             ErrorCode = "InvalidIds",
         };
     }
-    
+
     public static Result AddSingleValidationFailure(string propertyName, string message)
     {
-        return Result.Fail(new FluentValidationFailure(new Dictionary<string, string[]> { { propertyName, [message] } }));
+        return Result.Fail(
+            new FluentValidationFailure(
+                new Dictionary<string, string[]> { { propertyName, [message] } }
+            )
+        );
     }
 }

--- a/client/src/types/UserPermissions.ts
+++ b/client/src/types/UserPermissions.ts
@@ -66,6 +66,12 @@ export const UserPermissions = {
     SeeBetaExpressions: 'expression.seebetaexpressions',
     DownloadBooklet: 'expression.downloadbooklet',
   } as const,
+  Faction: {
+    Edit: 'faction.edit',
+    View: 'faction.view',
+    Create: 'faction.create',
+    Delete: 'faction.delete',
+  } as const,
   Powers: {
     Edit: 'powers.edit',
     View: 'powers.view',


### PR DESCRIPTION
API now supports
 - Grabbing all factions for a given expression
 - Add, editing, deleting a faction from / to an expression
 - This covers Name and Background fields

Scaffolder
 - Validators no longer need injectors, so removed those
 - Repository calls will now start with object name to match consistency elsewhere
 - Tweaked Required Field generator name
 - Get All in repository should now be as no tracking