### PR TITLE
Add Basic Faction Editing UI

### DIFF
--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
@@ -5,6 +5,8 @@ using ExpressedRealms.Expressions.API.FactionEndpoints.DeleteFaction;
 using ExpressedRealms.Expressions.API.FactionEndpoints.EditFaction;
 using ExpressedRealms.Expressions.API.FactionEndpoints.GetFaction;
 using ExpressedRealms.Expressions.API.FactionEndpoints.GetFactions;
+using ExpressedRealms.FeatureFlags;
+using ExpressedRealms.Server.Shared;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
@@ -14,7 +16,9 @@ internal static class FactionEndpoints
 {
     internal static void AddFactionEndpoints(this WebApplication app)
     {
-        var endpointGroup = app.MapGroup("factions").WithTags("Factions").RequireAuthorization();
+        var endpointGroup = app.MapGroup("factions").WithTags("Factions")
+            .RequireAuthorization()
+            .RequireFeatureToggle(ReleaseFlags.ShowFactions);
 
         endpointGroup.MapGet("expressions/{expressionId}", GetFactionsEndpoint.ExecuteAsync);
 

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/FactionEndpoints.cs
@@ -16,7 +16,8 @@ internal static class FactionEndpoints
 {
     internal static void AddFactionEndpoints(this WebApplication app)
     {
-        var endpointGroup = app.MapGroup("factions").WithTags("Factions")
+        var endpointGroup = app.MapGroup("factions")
+            .WithTags("Factions")
             .RequireAuthorization()
             .RequireFeatureToggle(ReleaseFlags.ShowFactions);
 

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
@@ -19,7 +19,8 @@ public static class GetFactionsEndpoint
             new FactionResponse()
             {
                 Factions = results
-                    .Value.Factions.Select(x => new FactionViewModel()
+                    .Value.Factions.OrderBy(x => x.Name)
+                    .Select(x => new FactionViewModel()
                     {
                         Id = x.Id,
                         Name = x.Name,

--- a/client/src/components/expressions/ExpressionBase.vue
+++ b/client/src/components/expressions/ExpressionBase.vue
@@ -23,6 +23,8 @@ import PowersToC from '@/components/expressions/PowersToC.vue'
 import ProgressionTab from '@/components/expressions/progressionPaths/ProgressionTab.vue'
 import ExpressionLogo from '@/components/common/ExpressionLogo.vue'
 import { can, userPermissionStore } from '@/stores/userPermissionStore.ts'
+import { hasFlag } from '@/stores/featureFlags/featureFlagStore.ts'
+import FactionTab from '@/components/expressions/factions/FactionTab.vue'
 
 const userPermissionInfo = userPermissionStore()
 const permissionCheck = userPermissionInfo.permissionCheck
@@ -164,6 +166,9 @@ const canCreate = computed(() => {
             <Tab value="0">
               Background
             </Tab>
+            <Tab v-if="hasFlag.ShowFactions" value="3">
+              Factions
+            </Tab>
             <Tab value="1">
               Powers
             </Tab>
@@ -186,6 +191,9 @@ const canCreate = computed(() => {
             </TabPanel>
             <TabPanel v-if="can.ProgressionPath.View" value="2">
               <ProgressionTab v-if="expressionInfo.isDoneLoading" :expression-id="expressionInfo.currentExpressionId" />
+            </TabPanel>
+            <TabPanel v-if="hasFlag.ShowFactions" value="3">
+              <FactionTab v-if="expressionInfo.isDoneLoading" :expression-id="expressionInfo.currentExpressionId" />
             </TabPanel>
           </TabPanels>
         </Tabs>

--- a/client/src/components/expressions/factions/FactionCreate.vue
+++ b/client/src/components/expressions/factions/FactionCreate.vue
@@ -1,32 +1,30 @@
 <script setup lang="ts">
 import toaster from '@/services/Toasters'
 
-import { inject, ref, type Ref } from 'vue'
+import { inject, type Ref } from 'vue'
 import Button from 'primevue/button'
 import FormWrapper from '@/FormWrappers/FormWrapper.vue'
-import { useQuery } from '@pinia/colada'
-import { useHydrateFormOnce } from '@/utilities/piniaColadaUtilities.ts'
-import type { EditSingleFactionInfo } from '@/components/expressions/factions/types.ts'
-import { factionQuery, factionUpdate } from '@/components/expressions/factions/stores/factionStore.ts'
+import type { CreateSingleFactionInfo } from '@/components/expressions/factions/types.ts'
+import { factionCreate } from '@/components/expressions/factions/stores/factionStore.ts'
 import { getValidationInstance } from '@/components/expressions/factions/validators/factionValidator.ts'
 import FormInputTextWrapper from '@/FormWrappers/FormInputTextWrapper.vue'
+import { expressionStore } from '@/stores/expressionStore.ts'
 import FormEditorWrapper from '@/FormWrappers/FormEditorWrapper.vue'
 
+const expressionInfo = expressionStore()
 const form = getValidationInstance()
 const dialogRef = inject('dialogRef') as Ref
-const factionId = ref(dialogRef.value.data.factionId as number)
 
-const { data, isPending } = useQuery(factionQuery(factionId.value))
-useHydrateFormOnce(data, form.setValues)
-
-const updateFactionFields = factionUpdate((errors) => {
+const updateFactionFields = factionCreate((errors) => {
   form.setErrors(errors)
 })
 
 const onSubmit = form.handleSubmit(async (values) => {
   await updateFactionFields.mutateAsync({
-    id: factionId.value,
-    data: values as EditSingleFactionInfo,
+    data: {
+      ...values,
+      expressionId: expressionInfo.currentExpressionId,
+    } as CreateSingleFactionInfo,
   })
   toaster.success('Faction fields updated successfully')
   cancel()
@@ -39,7 +37,7 @@ const cancel = () => {
 </script>
 
 <template>
-  <FormWrapper :show-skeleton="isPending" @submit="onSubmit">
+  <FormWrapper @submit="onSubmit">
     <FormInputTextWrapper v-model="form.fields.name" />
     <FormEditorWrapper v-model="form.fields.background" />
     <Button label="Update" class="m-2" type="submit" />

--- a/client/src/components/expressions/factions/FactionEdit.vue
+++ b/client/src/components/expressions/factions/FactionEdit.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import toaster from '@/services/Toasters'
+
+import { inject, ref, type Ref } from 'vue'
+import Button from 'primevue/button'
+import FormWrapper from '@/FormWrappers/FormWrapper.vue'
+import { useQuery } from '@pinia/colada'
+import { useHydrateFormOnce } from '@/utilities/piniaColadaUtilities.ts'
+import type { EditSingleFactionInfo } from '@/components/expressions/factions/types.ts'
+import { factionQuery, factionUpdate } from '@/components/expressions/factions/stores/factionStore.ts'
+import { getValidationInstance } from '@/components/expressions/factions/validators/factionValidator.ts'
+import FormInputTextWrapper from '@/FormWrappers/FormInputTextWrapper.vue'
+
+const form = getValidationInstance()
+const dialogRef = inject('dialogRef') as Ref
+const factionId = ref(dialogRef.value.data.factionId as number)
+
+const { data, isPending } = useQuery(factionQuery(factionId.value))
+useHydrateFormOnce(data, form.setValues)
+
+const updateFactionFields = factionUpdate((errors) => {
+  form.setErrors(errors)
+})
+
+const onSubmit = form.handleSubmit(async (values) => {
+  await updateFactionFields.mutateAsync({
+    id: factionId.value,
+    data: values as EditSingleFactionInfo,
+  })
+  toaster.success('Faction fields updated successfully')
+  cancel()
+})
+
+const cancel = () => {
+  dialogRef.value.close()
+}
+
+</script>
+
+<template>
+  <FormWrapper :show-skeleton="isPending" @submit="onSubmit">
+    <FormInputTextWrapper v-model="form.fields.name" />
+    <FormInputTextWrapper v-model="form.fields.background" />
+    <Button label="Update" class="m-2" type="submit" />
+  </FormWrapper>
+</template>

--- a/client/src/components/expressions/factions/FactionItem.vue
+++ b/client/src/components/expressions/factions/FactionItem.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+
+import { onMounted, type PropType } from 'vue'
+import Card from 'primevue/card'
+import { ConfirmationPopup } from './services/confirmationPopupService'
+import { useRouter } from 'vue-router'
+import SplitButton from 'primevue/splitbutton'
+import { userPermissionStore } from '@/stores/userPermissionStore.ts'
+import type { Faction } from '@/components/expressions/factions/types.ts'
+
+const userPermissionInfo = userPermissionStore()
+const permissionCheck = userPermissionInfo.permissionCheck
+const router = useRouter()
+
+const props = defineProps({
+  item: {
+    type: Object as PropType<Faction>,
+    required: true,
+  },
+})
+
+let popups = ConfirmationPopup(props.item.id, props.item.name)
+
+const items = []
+
+onMounted(async () => {
+  if (permissionCheck.Faction.Delete) {
+    items.push({
+      label: 'Delete',
+      command: ($event) => {
+        popups.deleteConfirmation($event)
+      },
+    })
+  }
+})
+
+async function toggleEdit() {
+  await router.push({ name: 'characterSheet', params: { id: props.item.id } })
+}
+</script>
+
+<template>
+  <Card>
+    <template #content>
+      <div class="d-flex flex-column flex-md-row align-self-center justify-content-between">
+        <div>
+          <h1 class="p-0 m-0">
+            {{ props.item?.name }}
+          </h1>
+          <div class="p-0 m-0">
+            <div>{{ props.item?.background }}</div>
+          </div>
+        </div>
+        <div class="p-0 m-0 d-inline-flex align-items-start">
+          <SplitButton label="View" severity="info" :model="items" @click="toggleEdit()" />
+        </div>
+      </div>
+    </template>
+  </Card>
+</template>

--- a/client/src/components/expressions/factions/FactionItem.vue
+++ b/client/src/components/expressions/factions/FactionItem.vue
@@ -1,17 +1,15 @@
 <script setup lang="ts">
 
-import { onMounted, type PropType } from 'vue'
+import { onMounted, type PropType, ref } from 'vue'
 import Card from 'primevue/card'
 import { ConfirmationPopup } from './services/confirmationPopupService'
-import { useRouter } from 'vue-router'
-import SplitButton from 'primevue/splitbutton'
 import { userPermissionStore } from '@/stores/userPermissionStore.ts'
 import type { Faction } from '@/components/expressions/factions/types.ts'
 import { factionDialogs } from '@/components/expressions/factions/services/dialogs.ts'
+import CommandButton, { type Command } from '@/uiComponents/CommandButton.vue'
 
 const userPermissionInfo = userPermissionStore()
 const permissionCheck = userPermissionInfo.permissionCheck
-const router = useRouter()
 
 const props = defineProps({
   item: {
@@ -23,30 +21,29 @@ const props = defineProps({
 let popups = ConfirmationPopup(props.item.id, props.item.name)
 let editItemPopup = factionDialogs()
 
-const items = []
+const items = ref<Command[]>([])
 
 onMounted(async () => {
-  if (permissionCheck.Faction.Delete) {
-    items.push({
-      label: 'Delete',
-      command: ($event) => {
-        popups.deleteConfirmation($event)
-      },
-    })
-  }
   if (permissionCheck.Faction.Edit) {
-    items.push({
+    items.value.push({
       label: 'Edit',
+      severity: 'primary',
       command: ($event) => {
         editItemPopup.showUpdateFaction(props.item.id)
       },
     })
   }
+  if (permissionCheck.Faction.Delete) {
+    items.value.push({
+      label: 'Delete',
+      command: ($event) => {
+        popups.deleteConfirmation($event)
+      },
+      severity: 'danger',
+    })
+  }
 })
 
-async function toggleEdit() {
-  await router.push({ name: 'characterSheet', params: { id: props.item.id } })
-}
 </script>
 
 <template>
@@ -62,7 +59,7 @@ async function toggleEdit() {
           </div>
         </div>
         <div class="p-0 m-0 d-inline-flex align-items-start">
-          <SplitButton label="View" severity="info" :model="items" @click="toggleEdit()" />
+          <CommandButton :commands="items" />
         </div>
       </div>
     </template>

--- a/client/src/components/expressions/factions/FactionItem.vue
+++ b/client/src/components/expressions/factions/FactionItem.vue
@@ -58,7 +58,7 @@ async function toggleEdit() {
             {{ props.item?.name }}
           </h1>
           <div class="p-0 m-0">
-            <div>{{ props.item?.background }}</div>
+            <div v-html="props.item.background" />
           </div>
         </div>
         <div class="p-0 m-0 d-inline-flex align-items-start">

--- a/client/src/components/expressions/factions/FactionItem.vue
+++ b/client/src/components/expressions/factions/FactionItem.vue
@@ -7,6 +7,7 @@ import { useRouter } from 'vue-router'
 import SplitButton from 'primevue/splitbutton'
 import { userPermissionStore } from '@/stores/userPermissionStore.ts'
 import type { Faction } from '@/components/expressions/factions/types.ts'
+import { factionDialogs } from '@/components/expressions/factions/services/dialogs.ts'
 
 const userPermissionInfo = userPermissionStore()
 const permissionCheck = userPermissionInfo.permissionCheck
@@ -20,6 +21,7 @@ const props = defineProps({
 })
 
 let popups = ConfirmationPopup(props.item.id, props.item.name)
+let editItemPopup = factionDialogs()
 
 const items = []
 
@@ -29,6 +31,14 @@ onMounted(async () => {
       label: 'Delete',
       command: ($event) => {
         popups.deleteConfirmation($event)
+      },
+    })
+  }
+  if (permissionCheck.Faction.Edit) {
+    items.push({
+      label: 'Edit',
+      command: ($event) => {
+        editItemPopup.showUpdateFaction(props.item.id)
       },
     })
   }

--- a/client/src/components/expressions/factions/FactionList.vue
+++ b/client/src/components/expressions/factions/FactionList.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+
+import { computed, ref } from 'vue'
+import Button from 'primevue/button'
+import Card from 'primevue/card'
+import { userPermissionStore } from '@/stores/userPermissionStore.ts'
+import Skeleton from 'primevue/skeleton'
+import { useRouter } from 'vue-router'
+import { useQueryWithLoading } from '@/utilities/queryOverride.ts'
+import FactionItem from '@/components/expressions/factions/FactionItem.vue'
+import { factionListQuery } from '@/components/expressions/factions/stores/factionStore.ts'
+
+const router = useRouter()
+const permissionCheck = userPermissionStore().permissionCheck
+
+const props = defineProps({
+  expressionId: {
+    type: Number,
+    required: true,
+  },
+})
+
+const { data, isLoading, error } = useQueryWithLoading(factionListQuery(props.expressionId))
+
+const showAdd = ref(false)
+
+const toggleAdd = async () => {
+  await router.push({ name: 'addWizard', query: { src: 'archetype_add' } })
+}
+
+const enableAdd = computed(() => {
+  return permissionCheck.Archetypes.Create
+})
+
+</script>
+
+<template>
+  <div class="d-flex flex-row align-items-center">
+    <div class="flex-fill" />
+    <div>
+      <Button
+        v-if="!showAdd && enableAdd" class="w-100 m-2"
+        label="Create Faction" @click="toggleAdd"
+      />
+    </div>
+  </div>
+  <div v-if="isLoading">
+    <Skeleton v-for="height in 3" :key="height" class="mb-3 mt-3" height="100px" />
+  </div>
+  <div v-else-if="error">
+    <Card>
+      <template #title>
+        Error Loading Factions
+      </template>
+      <template #content>
+        Please try again, or open an issue on discord
+      </template>
+    </Card>
+  </div>
+  <div v-else>
+    <div v-for="item in data!.factions" :key="item.id">
+      <FactionItem :item="item" />
+    </div>
+  </div>
+</template>

--- a/client/src/components/expressions/factions/FactionList.vue
+++ b/client/src/components/expressions/factions/FactionList.vue
@@ -5,13 +5,13 @@ import Button from 'primevue/button'
 import Card from 'primevue/card'
 import { userPermissionStore } from '@/stores/userPermissionStore.ts'
 import Skeleton from 'primevue/skeleton'
-import { useRouter } from 'vue-router'
 import { useQueryWithLoading } from '@/utilities/queryOverride.ts'
 import FactionItem from '@/components/expressions/factions/FactionItem.vue'
 import { factionListQuery } from '@/components/expressions/factions/stores/factionStore.ts'
+import { factionDialogs } from '@/components/expressions/factions/services/dialogs.ts'
 
-const router = useRouter()
 const permissionCheck = userPermissionStore().permissionCheck
+const dialogs = factionDialogs()
 
 const props = defineProps({
   expressionId: {
@@ -25,7 +25,7 @@ const { data, isLoading, error } = useQueryWithLoading(factionListQuery(props.ex
 const showAdd = ref(false)
 
 const toggleAdd = async () => {
-  await router.push({ name: 'addWizard', query: { src: 'archetype_add' } })
+  dialogs.showCreateFaction()
 }
 
 const enableAdd = computed(() => {

--- a/client/src/components/expressions/factions/FactionList.vue
+++ b/client/src/components/expressions/factions/FactionList.vue
@@ -56,6 +56,21 @@ const enableAdd = computed(() => {
       </template>
     </Card>
   </div>
+  <div v-else-if="data && data.factions.length === 0">
+    <Card>
+      <template #title>
+        No Factions
+      </template>
+      <template #content>
+        <p v-if="can.Faction.Create">
+          Create one to get started!
+        </p>
+        <p v-else>
+          There are no known factions for this expression
+        </p>
+      </template>
+    </Card>
+  </div>
   <div v-else>
     <div v-for="item in data!.factions" :key="item.id">
       <FactionItem :item="item" />

--- a/client/src/components/expressions/factions/FactionList.vue
+++ b/client/src/components/expressions/factions/FactionList.vue
@@ -3,14 +3,13 @@
 import { computed, ref } from 'vue'
 import Button from 'primevue/button'
 import Card from 'primevue/card'
-import { userPermissionStore } from '@/stores/userPermissionStore.ts'
+import { can } from '@/stores/userPermissionStore.ts'
 import Skeleton from 'primevue/skeleton'
 import { useQueryWithLoading } from '@/utilities/queryOverride.ts'
 import FactionItem from '@/components/expressions/factions/FactionItem.vue'
 import { factionListQuery } from '@/components/expressions/factions/stores/factionStore.ts'
 import { factionDialogs } from '@/components/expressions/factions/services/dialogs.ts'
 
-const permissionCheck = userPermissionStore().permissionCheck
 const dialogs = factionDialogs()
 
 const props = defineProps({
@@ -29,7 +28,7 @@ const toggleAdd = async () => {
 }
 
 const enableAdd = computed(() => {
-  return permissionCheck.Archetypes.Create
+  return can.Faction.Create
 })
 
 </script>

--- a/client/src/components/expressions/factions/FactionTab.vue
+++ b/client/src/components/expressions/factions/FactionTab.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import FactionList from '@/components/expressions/factions/FactionList.vue'
+
+const props = defineProps({
+  expressionId: {
+    type: Number,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <FactionList :expression-id="props.expressionId" />
+</template>

--- a/client/src/components/expressions/factions/services/confirmationPopupService.ts
+++ b/client/src/components/expressions/factions/services/confirmationPopupService.ts
@@ -1,0 +1,28 @@
+import { useConfirm } from 'primevue/useconfirm'
+import { useDeleteFaction } from '@/components/expressions/factions/stores/factionStore.ts'
+
+export const ConfirmationPopup = (id: number, name: string) => {
+  const confirm = useConfirm()
+  const { mutate: deleteFaction } = useDeleteFaction()
+  const deleteConfirmation = (event: MouseEvent) =>
+    confirm.require({
+      target: event.target as HTMLElement,
+      group: 'popup',
+      message: `Do you want to delete ${name}?`,
+      icon: 'pi pi-info-circle',
+      rejectProps: {
+        label: 'Cancel',
+        severity: 'secondary',
+        outlined: true,
+      },
+      acceptProps: {
+        label: 'Delete Archetype',
+        severity: 'danger',
+      },
+      accept: () => {
+        deleteFaction(id)
+      },
+    })
+
+  return { deleteConfirmation }
+}

--- a/client/src/components/expressions/factions/services/dialogs.ts
+++ b/client/src/components/expressions/factions/services/dialogs.ts
@@ -1,0 +1,28 @@
+import { useDialog } from 'primevue/usedialog'
+import FactionEdit from '@/components/expressions/factions/FactionEdit.vue'
+
+export const factionDialogs = () => {
+  const dialog = useDialog()
+
+  const showUpdateFaction = (factionId: number) => {
+    dialog.open(FactionEdit, {
+      props: {
+        header: 'Update Faction Fields',
+        style: {
+          width: '500px',
+        },
+        breakpoints: {
+          '960px': '75vw',
+          '640px': '90vw',
+        },
+        modal: true,
+      },
+      data: {
+        factionId: factionId,
+      },
+    })
+  }
+  return {
+    showUpdateFaction,
+  }
+}

--- a/client/src/components/expressions/factions/services/dialogs.ts
+++ b/client/src/components/expressions/factions/services/dialogs.ts
@@ -1,5 +1,6 @@
 import { useDialog } from 'primevue/usedialog'
 import FactionEdit from '@/components/expressions/factions/FactionEdit.vue'
+import FactionCreate from '@/components/expressions/factions/FactionCreate.vue'
 
 export const factionDialogs = () => {
   const dialog = useDialog()
@@ -7,7 +8,7 @@ export const factionDialogs = () => {
   const showUpdateFaction = (factionId: number) => {
     dialog.open(FactionEdit, {
       props: {
-        header: 'Update Faction Fields',
+        header: 'Update Faction',
         style: {
           width: '500px',
         },
@@ -22,7 +23,26 @@ export const factionDialogs = () => {
       },
     })
   }
+
+  const showCreateFaction = () => {
+    dialog.open(FactionCreate, {
+      props: {
+        header: 'Create Faction',
+        style: {
+          width: '500px',
+        },
+        breakpoints: {
+          '960px': '75vw',
+          '640px': '90vw',
+        },
+        modal: true,
+      },
+      data: {
+      },
+    })
+  }
   return {
     showUpdateFaction,
+    showCreateFaction,
   }
 }

--- a/client/src/components/expressions/factions/services/factionService.ts
+++ b/client/src/components/expressions/factions/services/factionService.ts
@@ -1,8 +1,12 @@
 import axios from 'axios'
-import type { FactionResponse } from '@/components/expressions/factions/types.ts'
+import type { EditSingleFactionInfo, FactionResponse } from '@/components/expressions/factions/types.ts'
 
 export const factionService = {
   getFactions: (expressionId: number): Promise<FactionResponse> => axios.get<FactionResponse>(`/factions/expressions/${expressionId}`)
+    .then(async (response) => { return response.data }),
+  getFaction: (id: number): Promise<EditSingleFactionInfo> => axios.get<EditSingleFactionInfo>(`/factions/${id}`)
+    .then(async (response) => { return response.data }),
+  editFaction: (id: number, faction: EditSingleFactionInfo): Promise<EditSingleFactionInfo> => axios.put<EditSingleFactionInfo>(`/factions/${id}`, faction)
     .then(async (response) => { return response.data }),
   delete: (id: number) => axios.delete(`/factions/${id}`)
     .then(async (response) => { return response.data }),

--- a/client/src/components/expressions/factions/services/factionService.ts
+++ b/client/src/components/expressions/factions/services/factionService.ts
@@ -1,0 +1,9 @@
+import axios from 'axios'
+import type { FactionResponse } from '@/components/expressions/factions/types.ts'
+
+export const factionService = {
+  getFactions: (expressionId: number): Promise<FactionResponse> => axios.get<FactionResponse>(`/factions/expressions/${expressionId}`)
+    .then(async (response) => { return response.data }),
+  delete: (id: number) => axios.delete(`/factions/${id}`)
+    .then(async (response) => { return response.data }),
+}

--- a/client/src/components/expressions/factions/services/factionService.ts
+++ b/client/src/components/expressions/factions/services/factionService.ts
@@ -1,5 +1,9 @@
 import axios from 'axios'
-import type { EditSingleFactionInfo, FactionResponse } from '@/components/expressions/factions/types.ts'
+import type {
+  CreateSingleFactionInfo,
+  EditSingleFactionInfo,
+  FactionResponse,
+} from '@/components/expressions/factions/types.ts'
 
 export const factionService = {
   getFactions: (expressionId: number): Promise<FactionResponse> => axios.get<FactionResponse>(`/factions/expressions/${expressionId}`)
@@ -7,6 +11,8 @@ export const factionService = {
   getFaction: (id: number): Promise<EditSingleFactionInfo> => axios.get<EditSingleFactionInfo>(`/factions/${id}`)
     .then(async (response) => { return response.data }),
   editFaction: (id: number, faction: EditSingleFactionInfo): Promise<EditSingleFactionInfo> => axios.put<EditSingleFactionInfo>(`/factions/${id}`, faction)
+    .then(async (response) => { return response.data }),
+  createFaction: (faction: CreateSingleFactionInfo): Promise<number> => axios.post<number>(`/factions/`, faction)
     .then(async (response) => { return response.data }),
   delete: (id: number) => axios.delete(`/factions/${id}`)
     .then(async (response) => { return response.data }),

--- a/client/src/components/expressions/factions/stores/factionStore.ts
+++ b/client/src/components/expressions/factions/stores/factionStore.ts
@@ -1,0 +1,25 @@
+import { defineQueryOptions, useMutation, useQueryCache } from '@pinia/colada'
+import toaster from '@/services/Toasters'
+import { factionService } from '@/components/expressions/factions/services/factionService.ts'
+
+export const FACTION_QUERY_KEYS = {
+  root: ['faction'] as const,
+  getFactionList: (expressionId: number) => ['faction', 'list', expressionId] as const,
+}
+
+export const factionListQuery = defineQueryOptions((expressionId: number) => ({
+  key: FACTION_QUERY_KEYS.getFactionList(expressionId),
+  query: () => factionService.getFactions(expressionId),
+}))
+
+export const useDeleteFaction = () => {
+  const queryCache = useQueryCache()
+
+  return useMutation({
+    mutation: (id: number) => factionService.delete(id),
+    async onSuccess() {
+      toaster.success('Faction deleted successfully')
+      await queryCache.invalidateQueries({ key: FACTION_QUERY_KEYS.root })
+    },
+  })
+}

--- a/client/src/components/expressions/factions/stores/factionStore.ts
+++ b/client/src/components/expressions/factions/stores/factionStore.ts
@@ -2,7 +2,7 @@ import { defineQuery, defineQueryOptions, useMutation, useQueryCache } from '@pi
 import toaster from '@/services/Toasters'
 import { factionService } from '@/components/expressions/factions/services/factionService.ts'
 import { handleValidationErrors } from '@/utilities/piniaColadaUtilities.ts'
-import type { EditSingleFactionInfo } from '@/components/expressions/factions/types.ts'
+import type { CreateSingleFactionInfo, EditSingleFactionInfo } from '@/components/expressions/factions/types.ts'
 
 export const FACTION_QUERY_KEYS = {
   root: ['faction'] as const,
@@ -38,6 +38,20 @@ export const factionUpdate = (onValidationError?: (errors: Record<string, any>) 
 
   return useMutation({
     mutation: ({ id, data }: { id: number, data: EditSingleFactionInfo }) => factionService.editFaction(id, data),
+    async onSuccess() {
+      await queryCache.invalidateQueries({ key: FACTION_QUERY_KEYS.root })
+    },
+    onError(error: any) {
+      handleValidationErrors(error, onValidationError)
+    },
+  })
+}
+
+export const factionCreate = (onValidationError?: (errors: Record<string, any>) => void | undefined) => {
+  const queryCache = useQueryCache()
+
+  return useMutation({
+    mutation: ({ data }: { data: CreateSingleFactionInfo }) => factionService.createFaction(data),
     async onSuccess() {
       await queryCache.invalidateQueries({ key: FACTION_QUERY_KEYS.root })
     },

--- a/client/src/components/expressions/factions/stores/factionStore.ts
+++ b/client/src/components/expressions/factions/stores/factionStore.ts
@@ -1,10 +1,13 @@
-import { defineQueryOptions, useMutation, useQueryCache } from '@pinia/colada'
+import { defineQuery, defineQueryOptions, useMutation, useQueryCache } from '@pinia/colada'
 import toaster from '@/services/Toasters'
 import { factionService } from '@/components/expressions/factions/services/factionService.ts'
+import { handleValidationErrors } from '@/utilities/piniaColadaUtilities.ts'
+import type { EditSingleFactionInfo } from '@/components/expressions/factions/types.ts'
 
 export const FACTION_QUERY_KEYS = {
   root: ['faction'] as const,
   getFactionList: (expressionId: number) => ['faction', 'list', expressionId] as const,
+  getFaction: (id: number) => ['faction', id] as const,
 }
 
 export const factionListQuery = defineQueryOptions((expressionId: number) => ({
@@ -20,6 +23,26 @@ export const useDeleteFaction = () => {
     async onSuccess() {
       toaster.success('Faction deleted successfully')
       await queryCache.invalidateQueries({ key: FACTION_QUERY_KEYS.root })
+    },
+  })
+}
+
+export const factionQuery = (id: number) =>
+  defineQuery(() => ({
+    key: FACTION_QUERY_KEYS.getFaction(id),
+    query: () => factionService.getFaction(id),
+  }))
+
+export const factionUpdate = (onValidationError?: (errors: Record<string, any>) => void | undefined) => {
+  const queryCache = useQueryCache()
+
+  return useMutation({
+    mutation: ({ id, data }: { id: number, data: EditSingleFactionInfo }) => factionService.editFaction(id, data),
+    async onSuccess() {
+      await queryCache.invalidateQueries({ key: FACTION_QUERY_KEYS.root })
+    },
+    onError(error: any) {
+      handleValidationErrors(error, onValidationError)
     },
   })
 }

--- a/client/src/components/expressions/factions/types.ts
+++ b/client/src/components/expressions/factions/types.ts
@@ -5,5 +5,10 @@ export interface FactionResponse {
 export interface Faction {
   id: number
   name: string
-  background: string | null
+  background: string
+}
+
+export interface EditSingleFactionInfo {
+  name: string
+  background: string
 }

--- a/client/src/components/expressions/factions/types.ts
+++ b/client/src/components/expressions/factions/types.ts
@@ -1,0 +1,9 @@
+export interface FactionResponse {
+  factions: Array<Faction>
+}
+
+export interface Faction {
+  id: number
+  name: string
+  background: string | null
+}

--- a/client/src/components/expressions/factions/types.ts
+++ b/client/src/components/expressions/factions/types.ts
@@ -12,3 +12,9 @@ export interface EditSingleFactionInfo {
   name: string
   background: string
 }
+
+export interface CreateSingleFactionInfo {
+  name: string
+  background: string
+  expressionId: number
+}

--- a/client/src/components/expressions/factions/validators/factionValidator.ts
+++ b/client/src/components/expressions/factions/validators/factionValidator.ts
@@ -1,0 +1,31 @@
+import { object, string } from 'yup'
+import { type GenericForm, useGenericForm } from '@/utilities/formUtilities'
+import type { EditSingleFactionInfo } from '@/components/expressions/factions/types.ts'
+
+const validationSchema = object({
+  name: string()
+    .required()
+    .max(250)
+    .label('Name'),
+  background: string()
+    .required()
+    .max(20_000)
+    .label('Background'),
+}).transform(values => ({
+  name: values.name,
+  background: values.background,
+} as EditSingleFactionInfo))
+
+export function getValidationInstance(): GenericForm<EditSingleFactionInfo> {
+  const form = useGenericForm(validationSchema)
+
+  const setValues = (data: EditSingleFactionInfo) => {
+    form.fields.name.field.value = 'test'
+    form.fields.background.field.value = data.background
+  }
+
+  return {
+    ...form,
+    setValues,
+  }
+}

--- a/client/src/components/expressions/factions/validators/factionValidator.ts
+++ b/client/src/components/expressions/factions/validators/factionValidator.ts
@@ -20,7 +20,7 @@ export function getValidationInstance(): GenericForm<EditSingleFactionInfo> {
   const form = useGenericForm(validationSchema)
 
   const setValues = (data: EditSingleFactionInfo) => {
-    form.fields.name.field.value = 'test'
+    form.fields.name.field.value = data.name
     form.fields.background.field.value = data.background
   }
 

--- a/client/src/uiComponents/CommandButton.vue
+++ b/client/src/uiComponents/CommandButton.vue
@@ -8,7 +8,7 @@ export interface Command {
   label: string
   command: (event: any) => void
   isVisible?: boolean
-  severity?: string | 'secondary' | 'success' | 'info' | 'warn' | 'help' | 'danger' | 'contrast' | undefined
+  severity?: string | 'secondary' | 'success' | 'info' | 'warn' | 'help' | 'danger' | 'contrast'
 }
 
 const props = defineProps({

--- a/client/src/uiComponents/CommandButton.vue
+++ b/client/src/uiComponents/CommandButton.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+
+import { computed, type PropType } from 'vue'
+import SplitButton from 'primevue/splitbutton'
+import Button from 'primevue/button'
+
+export interface Command {
+  label: string
+  command: (event: any) => void
+  isVisible?: boolean
+  severity?: string | 'secondary' | 'success' | 'info' | 'warn' | 'help' | 'danger' | 'contrast' | undefined
+}
+
+const props = defineProps({
+  commands: {
+    type: Object as PropType<Command[]>,
+    required: true,
+  },
+})
+
+const mainCommand = computed(() => props.commands[0])
+const subCommands = computed(() => props.commands.slice(1).map(command => ({ label: command.label, command: command.command })))
+
+</script>
+
+<template>
+  <div v-if="props.commands.length == 0" />
+  <div v-else-if="props.commands.length == 1">
+    <Button :label="mainCommand.label" :severity="mainCommand.severity" @click="mainCommand.command" />
+  </div>
+  <div v-else>
+    <SplitButton :label="mainCommand.label" :severity="mainCommand.severity" :model="subCommands" @click="mainCommand.command" />
+  </div>
+</template>


### PR DESCRIPTION
 - Factions are now Alphabetically organized
 - One can now Add / Edit / Delete factions to / from expressions
 - This is currently hidden behind a feature flag
 - Added Command Button - Allows one to pass in a series of commands and have it automatically choose between showing nothing, showing a single button and showing a split button depending on the number of items
 - As an interesting side note - now have a full example of using pinia colada, with edit functionality