### PR TITLE
Add Add Power Support to Faction Levels

### DIFF
--- a/api/ExpressedRealms.DB/Migrations/20260702120540_AddPowerToFactionLevel.Designer.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260702120540_AddPowerToFactionLevel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ExpressedRealms.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ExpressedRealms.DB.Migrations
 {
     [DbContext(typeof(ExpressedRealmsDbContext))]
-    partial class ExpressedRealmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702120540_AddPowerToFactionLevel")]
+    partial class AddPowerToFactionLevel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/ExpressedRealms.DB/Migrations/20260702120540_AddPowerToFactionLevel.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260702120540_AddPowerToFactionLevel.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpressedRealms.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPowerToFactionLevel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "power_id",
+                table: "faction_levels",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_faction_levels_power_id",
+                table: "faction_levels",
+                column: "power_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_faction_levels_powers_power_id",
+                table: "faction_levels",
+                column: "power_id",
+                principalTable: "powers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_faction_levels_powers_power_id",
+                table: "faction_levels");
+
+            migrationBuilder.DropIndex(
+                name: "ix_faction_levels_power_id",
+                table: "faction_levels");
+
+            migrationBuilder.DropColumn(
+                name: "power_id",
+                table: "faction_levels");
+        }
+    }
+}

--- a/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/Audit/FactionLevelsAuditTrailExtensions.cs
+++ b/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/Audit/FactionLevelsAuditTrailExtensions.cs
@@ -24,7 +24,7 @@ internal static class FactionLevelAuditTrailExtensions
                 case "knowledge_level_id":
                     changedRecord.FriendlyName = "Knowledge Level";
                     break;
-                
+
                 case "power_id":
                     changedRecord.FriendlyName = "Power";
                     break;

--- a/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/Audit/FactionLevelsAuditTrailExtensions.cs
+++ b/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/Audit/FactionLevelsAuditTrailExtensions.cs
@@ -24,6 +24,10 @@ internal static class FactionLevelAuditTrailExtensions
                 case "knowledge_level_id":
                     changedRecord.FriendlyName = "Knowledge Level";
                     break;
+                
+                case "power_id":
+                    changedRecord.FriendlyName = "Power";
+                    break;
 
                 case "specialization":
                     changedRecord.FriendlyName = "Specialization";

--- a/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/FactionLevel.cs
+++ b/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/FactionLevel.cs
@@ -5,6 +5,7 @@ using ExpressedRealms.DB.Models.Factions.FactionModels;
 using ExpressedRealms.DB.Models.Factions.FactionRankModels;
 using ExpressedRealms.DB.Models.Knowledges.KnowledgeEducationLevels;
 using ExpressedRealms.DB.Models.Knowledges.KnowledgeModels;
+using ExpressedRealms.DB.Models.Powers;
 
 namespace ExpressedRealms.DB.Models.Factions.FactionLevelModels;
 
@@ -17,6 +18,7 @@ public class FactionLevel : ISoftDelete
     public int? KnowledgeId { get; set; }
     public int? KnowledgeLevelId { get; set; }
     public string? Specialization { get; set; }
+    public int? PowerId { get; set; }
 
     public bool IsDeleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
@@ -25,6 +27,7 @@ public class FactionLevel : ISoftDelete
     public virtual FactionRank FactionRank { get; set; } = null!;
     public virtual Knowledge? Knowledge { get; set; }
     public virtual KnowledgeEducationLevel? KnowledgeLevel { get; set; }
+    public virtual Power? Power { get; set; }
     public virtual ICollection<FactionLevelAuditTrail> FactionLevelAuditTrails { get; set; } =
         new HashSet<FactionLevelAuditTrail>();
 }

--- a/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/FactionLevelConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/FactionLevelConfiguration.cs
@@ -40,7 +40,7 @@ public class FactionLevelConfiguration : IEntityTypeConfiguration<FactionLevel>
             .WithMany(x => x.FactionLevels)
             .HasForeignKey(x => x.KnowledgeLevelId)
             .OnDelete(DeleteBehavior.Restrict);
-        
+
         builder
             .HasOne(x => x.Power)
             .WithMany(x => x.FactionLevels)

--- a/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/FactionLevelConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Factions/FactionLevelModels/FactionLevelConfiguration.cs
@@ -40,6 +40,12 @@ public class FactionLevelConfiguration : IEntityTypeConfiguration<FactionLevel>
             .WithMany(x => x.FactionLevels)
             .HasForeignKey(x => x.KnowledgeLevelId)
             .OnDelete(DeleteBehavior.Restrict);
+        
+        builder
+            .HasOne(x => x.Power)
+            .WithMany(x => x.FactionLevels)
+            .HasForeignKey(x => x.PowerId)
+            .OnDelete(DeleteBehavior.Restrict);
 
         builder.HasQueryFilter(x => !x.IsDeleted);
         builder.Property(e => e.IsDeleted);

--- a/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
+++ b/api/ExpressedRealms.DB/Models/Powers/PowerSetup/Power.cs
@@ -1,5 +1,6 @@
 using Audit.EntityFramework;
 using ExpressedRealms.DB.Interceptors;
+using ExpressedRealms.DB.Models.Factions.FactionLevelModels;
 using ExpressedRealms.DB.Models.ModifierSystem.StatModifierGroups;
 using ExpressedRealms.DB.Models.Powers.CharacterPowerMappingSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
@@ -48,4 +49,6 @@ public class Power : ISoftDelete
     public virtual List<PowerPrerequisitePower> PrerequisitePowers { get; set; } = null!;
     public virtual List<PowerAuditTrail> PowerAuditTrails { get; set; } = null!;
     public virtual List<CharacterPowerMapping> CharacterPowerMappings { get; set; } = null!;
+    public virtual ICollection<FactionLevel> FactionLevels { get; set; } =
+        new HashSet<FactionLevel>();
 }

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/FactionLevelModel.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/FactionLevelModel.cs
@@ -9,4 +9,5 @@ public class FactionLevelModel
     public string? KnowledgeLevel { get; set; }
     public string? Specialization { get; set; }
     public int? KnowledgeLevelId { get; set; }
+    public int? PowerId { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
@@ -35,7 +35,7 @@ public static class GetFactionsEndpoint
                                 KnowledgeLevel = y.KnowledgeLevel,
                                 Specialization = y.Specialization,
                                 KnowledgeLevelId = y.KnowledgeLevelId,
-                                PowerId = y.PowerId
+                                PowerId = y.PowerId,
                             })
                             .ToList(),
                     })

--- a/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/FactionEndpoints/GetFactions/GetFactionsEndpoint.cs
@@ -35,6 +35,7 @@ public static class GetFactionsEndpoint
                                 KnowledgeLevel = y.KnowledgeLevel,
                                 Specialization = y.Specialization,
                                 KnowledgeLevelId = y.KnowledgeLevelId,
+                                PowerId = y.PowerId
                             })
                             .ToList(),
                     })

--- a/api/ExpressedRealms.Expressions.Repository/Factions/Dtos/FactionLevelListDto.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Factions/Dtos/FactionLevelListDto.cs
@@ -9,4 +9,5 @@ public class FactionLevelListDto
     public string? KnowledgeLevel { get; set; }
     public string? Specialization { get; set; }
     public int? KnowledgeLevelId { get; set; }
+    public int? PowerId { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.Repository/Factions/FactionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Factions/FactionRepository.cs
@@ -68,6 +68,7 @@ internal sealed class FactionRepository(
                                 : $"{y.KnowledgeLevel!.Name} ({y.KnowledgeLevel.Level})",
                         KnowledgeLevelId = y.KnowledgeLevelId,
                         Specialization = y.Specialization,
+                        PowerId = y.PowerId
                     })
                     .ToList(),
             })

--- a/api/ExpressedRealms.Expressions.Repository/Factions/FactionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/Factions/FactionRepository.cs
@@ -68,7 +68,7 @@ internal sealed class FactionRepository(
                                 : $"{y.KnowledgeLevel!.Name} ({y.KnowledgeLevel.Level})",
                         KnowledgeLevelId = y.KnowledgeLevelId,
                         Specialization = y.Specialization,
-                        PowerId = y.PowerId
+                        PowerId = y.PowerId,
                     })
                     .ToList(),
             })

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionsUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionsUseCaseTests.cs
@@ -67,7 +67,7 @@ public class GetFactionsUseCaseTests
                         Id = 5,
                         Specialization = "Bar",
                         KnowledgeId = 3,
-                        PowerId = 8
+                        PowerId = 8,
                     },
                 },
             },
@@ -99,7 +99,7 @@ public class GetFactionsUseCaseTests
                             Id = 5,
                             Specialization = "Bar",
                             KnowledgeId = 3,
-                            PowerId = 8
+                            PowerId = 8,
                         },
                     },
                 },

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionsUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/Factions/GetFactionsUseCaseTests.cs
@@ -67,6 +67,7 @@ public class GetFactionsUseCaseTests
                         Id = 5,
                         Specialization = "Bar",
                         KnowledgeId = 3,
+                        PowerId = 8
                     },
                 },
             },
@@ -98,6 +99,7 @@ public class GetFactionsUseCaseTests
                             Id = 5,
                             Specialization = "Bar",
                             KnowledgeId = 3,
+                            PowerId = 8
                         },
                     },
                 },

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/FactionLevel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/FactionLevel.cs
@@ -9,4 +9,5 @@ public class FactionLevelModel
     public string? KnowledgeLevel { get; set; }
     public string? Specialization { get; set; }
     public int? KnowledgeLevelId { get; set; }
+    public int? PowerId { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsUseCase.cs
@@ -42,7 +42,7 @@ internal sealed class GetFactionsUseCase(
                                 KnowledgeLevel = y.KnowledgeLevel,
                                 Specialization = y.Specialization,
                                 KnowledgeLevelId = y.KnowledgeLevelId,
-                                PowerId = y.PowerId
+                                PowerId = y.PowerId,
                             })
                             .ToList(),
                     })

--- a/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/FactionUseCases/GetFactions/GetFactionsUseCase.cs
@@ -42,6 +42,7 @@ internal sealed class GetFactionsUseCase(
                                 KnowledgeLevel = y.KnowledgeLevel,
                                 Specialization = y.Specialization,
                                 KnowledgeLevelId = y.KnowledgeLevelId,
+                                PowerId = y.PowerId
                             })
                             .ToList(),
                     })

--- a/api/ExpressedRealms.Powers.API/PowerEndpoints/CreatePower/CreatePowerEndpoint.cs
+++ b/api/ExpressedRealms.Powers.API/PowerEndpoints/CreatePower/CreatePowerEndpoint.cs
@@ -15,6 +15,7 @@ public static class CreatePowerEndpoint
         var results = await repository.ExecuteAsync(
             new CreatePowerModel()
             {
+                Target = request.Target,
                 Name = request.Name,
                 Category = request.CategoryIds,
                 Description = request.Description,
@@ -25,7 +26,7 @@ public static class CreatePowerEndpoint
                 PowerLevel = request.PowerLevel,
                 PowerActivationType = request.PowerActivationType,
                 Other = request.Other,
-                PowerPathId = request.PowerPathId,
+                TargetId = request.TargetId,
                 IsPowerUse = request.IsPowerUse,
                 Cost = request.Cost,
             }

--- a/api/ExpressedRealms.Powers.API/PowerEndpoints/CreatePower/CreatePowerEndpoint.cs
+++ b/api/ExpressedRealms.Powers.API/PowerEndpoints/CreatePower/CreatePowerEndpoint.cs
@@ -1,5 +1,4 @@
-using ExpressedRealms.Powers.Repository.Powers;
-using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerCreate;
+using ExpressedRealms.Powers.UseCases.Powers.CreatePower;
 using ExpressedRealms.Server.Shared;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -10,10 +9,10 @@ public static class CreatePowerEndpoint
 {
     public static async Task<Results<ValidationProblem, NotFound, Created<int>>> Execute(
         CreatePowerRequest request,
-        IPowerRepository repository
+        ICreatePowerUseCase repository
     )
     {
-        var results = await repository.CreatePower(
+        var results = await repository.ExecuteAsync(
             new CreatePowerModel()
             {
                 Name = request.Name,

--- a/api/ExpressedRealms.Powers.API/PowerEndpoints/CreatePower/CreatePowerRequest.cs
+++ b/api/ExpressedRealms.Powers.API/PowerEndpoints/CreatePower/CreatePowerRequest.cs
@@ -3,7 +3,7 @@ namespace ExpressedRealms.Powers.API.PowerEndpoints.CreatePower;
 public class CreatePowerRequest
 {
     public required string Name { get; set; }
-    public List<int>? CategoryIds { get; set; }
+    public List<int> CategoryIds { get; set; } = new();
     public required string Description { get; set; }
     public required string GameMechanicEffect { get; set; }
     public string? Limitation { get; set; }

--- a/api/ExpressedRealms.Powers.API/PowerEndpoints/CreatePower/CreatePowerRequest.cs
+++ b/api/ExpressedRealms.Powers.API/PowerEndpoints/CreatePower/CreatePowerRequest.cs
@@ -1,7 +1,11 @@
+using ExpressedRealms.Powers.UseCases.Powers.CreatePower;
+
 namespace ExpressedRealms.Powers.API.PowerEndpoints.CreatePower;
 
 public class CreatePowerRequest
 {
+    public CreatePowerTarget Target { get; set; }
+    public int TargetId { get; set; }
     public required string Name { get; set; }
     public List<int> CategoryIds { get; set; } = new();
     public required string Description { get; set; }
@@ -12,7 +16,6 @@ public class CreatePowerRequest
     public int PowerLevel { get; set; }
     public byte PowerActivationType { get; set; }
     public string? Other { get; set; }
-    public int PowerPathId { get; set; }
     public bool IsPowerUse { get; set; }
     public string? Cost { get; set; }
 }

--- a/api/ExpressedRealms.Powers.Repository/PowerPaths/IPowerPathRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/PowerPaths/IPowerPathRepository.cs
@@ -1,3 +1,4 @@
+using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 using ExpressedRealms.Powers.Repository.PowerPaths.DTOs.PowerPathCreate;
 using ExpressedRealms.Powers.Repository.PowerPaths.DTOs.PowerPathEdit;
 using ExpressedRealms.Powers.Repository.PowerPaths.DTOs.PowerPathLIst;
@@ -17,4 +18,5 @@ public interface IPowerPathRepository
     Task<Result> UpdatePowerPathSortOrder(EditPowerPathSortModel dto);
     Task<Result<List<PowerPathToc>>> GetPowerPathAndPowers(int expressionId);
     Task<Result<List<PowerPathToc>>> GetPowerPathAndPowers(List<int> powerIds);
+    Task AddPowerToPowerPath(PowerPathPowerMapping model);
 }

--- a/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
@@ -1,5 +1,6 @@
 using ExpressedRealms.DB;
 using ExpressedRealms.DB.Interceptors;
+using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 using ExpressedRealms.DB.Models.Powers.PowerPathSetup;
 using ExpressedRealms.Powers.Repository.PowerPaths.DTOs.PowerPathCreate;
 using ExpressedRealms.Powers.Repository.PowerPaths.DTOs.PowerPathEdit;
@@ -184,5 +185,18 @@ internal sealed class PowerPathRepository(
 
         await context.SaveChangesAsync();
         return Result.Ok();
+    }
+    
+    public async Task AddPowerToPowerPath(PowerPathPowerMapping model)
+    {
+        var nextPlaceOnList = await context
+            .PowerPathPowerMappings.AsNoTracking()
+            .Where(x => x.PowerPathId == model.PowerPathId)
+            .CountAsync();
+        
+        model.OrderIndex = nextPlaceOnList + 1;
+
+        context.PowerPathPowerMappings.Add(model);
+        await context.SaveChangesAsync();
     }
 }

--- a/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/PowerPaths/PowerPathRepository.cs
@@ -186,14 +186,14 @@ internal sealed class PowerPathRepository(
         await context.SaveChangesAsync();
         return Result.Ok();
     }
-    
+
     public async Task AddPowerToPowerPath(PowerPathPowerMapping model)
     {
         var nextPlaceOnList = await context
             .PowerPathPowerMappings.AsNoTracking()
             .Where(x => x.PowerPathId == model.PowerPathId)
             .CountAsync();
-        
+
         model.OrderIndex = nextPlaceOnList + 1;
 
         context.PowerPathPowerMappings.Add(model);

--- a/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerEdit/EditPowerModelValidator.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/DTOs/PowerEdit/EditPowerModelValidator.cs
@@ -1,5 +1,4 @@
 using ExpressedRealms.DB;
-using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerCreate;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 

--- a/api/ExpressedRealms.Powers.Repository/Powers/IPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/IPowerRepository.cs
@@ -23,4 +23,5 @@ public interface IPowerRepository
     Task<bool> IsValidRequirement(int id);
     Task<PowerLevel> GetPowerLevelForPower(int id);
     Task<int> GetPowerExperienceCost(int powerId);
+    Task AddPowerToFactionLevel(int powerId, int targetId);
 }

--- a/api/ExpressedRealms.Powers.Repository/Powers/IPowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/IPowerRepository.cs
@@ -1,6 +1,5 @@
 using ExpressedRealms.DB.Models.Powers;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.Options;
-using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerCreate;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerEdit;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerList;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerSorting;
@@ -11,7 +10,7 @@ namespace ExpressedRealms.Powers.Repository.Powers;
 public interface IPowerRepository
 {
     Task<Result<List<PowerInformation>>> GetPowersAsync(int powerPathId);
-    Task<Result<int>> CreatePower(CreatePowerModel createPowerModel);
+    Task<int> CreatePower(Power power);
     Task<Result> EditPower(EditPowerModel editPowerModel);
     Task<Result> DeletePowerAsync(int id);
     Task<Result<PowerOptions>> GetPowerOptionsAsync();

--- a/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
@@ -1,9 +1,7 @@
 using ExpressedRealms.DB;
 using ExpressedRealms.DB.Interceptors;
 using ExpressedRealms.DB.Models.Powers;
-using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.Options;
-using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerCreate;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerEdit;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerList;
 using ExpressedRealms.Powers.Repository.Powers.DTOs.PowerSorting;
@@ -16,7 +14,6 @@ namespace ExpressedRealms.Powers.Repository.Powers;
 
 internal sealed class PowerRepository(
     ExpressedRealmsDbContext context,
-    CreatePowerModelValidator createPowerModelValidator,
     EditPowerModelValidator editPowerModelValidator,
     CancellationToken cancellationToken
 ) : IPowerRepository
@@ -140,66 +137,11 @@ internal sealed class PowerRepository(
         );
     }
 
-    public async Task<Result<int>> CreatePower(CreatePowerModel createPowerModel)
+    public async Task<int> CreatePower(Power power)
     {
-        var result = await ValidationHelper.ValidateAndHandleErrorsAsync(
-            createPowerModelValidator,
-            createPowerModel,
-            cancellationToken
-        );
-
-        if (result.IsFailed)
-            return Result.Fail(result.Errors);
-
-        var nextPlaceOnList = await context
-            .PowerPathPowerMappings.AsNoTracking()
-            .Where(x => x.PowerPathId == createPowerModel.PowerPathId)
-            .CountAsync();
-
-        var newPower = new Power
-        {
-            Name = createPowerModel.Name,
-            Description = createPowerModel.Description,
-            LevelId = createPowerModel.PowerLevel,
-            AreaOfEffectTypeId = createPowerModel.AreaOfEffect,
-            ActivationTimingTypeId = createPowerModel.PowerActivationType,
-            DurationId = createPowerModel.PowerDuration,
-            IsPowerUse = createPowerModel.IsPowerUse,
-            GameMechanicEffect = createPowerModel.GameMechanicEffect,
-            Limitation = createPowerModel.Limitation,
-            OtherFields = createPowerModel.Other,
-            Cost = createPowerModel.Cost,
-        };
-
-        context.Powers.Add(newPower);
+        context.Powers.Add(power);
         await context.SaveChangesAsync(cancellationToken);
-
-        context.PowerPathPowerMappings.Add(
-            new PowerPathPowerMapping()
-            {
-                PowerId = newPower.Id,
-                PowerPathId = createPowerModel.PowerPathId,
-                OrderIndex = nextPlaceOnList + 1,
-            }
-        );
-
-        if (createPowerModel.Category == null || createPowerModel.Category.Count == 0)
-        {
-            await context.SaveChangesAsync(cancellationToken);
-            return Result.Ok(newPower.Id);
-        }
-
-        context.PowerCategoryMappings.AddRange(
-            createPowerModel.Category.Select(x => new PowerCategoryMapping()
-            {
-                PowerId = newPower.Id,
-                CategoryId = x,
-            })
-        );
-
-        await context.SaveChangesAsync(cancellationToken);
-
-        return Result.Ok(newPower.Id);
+        return power.Id;
     }
 
     public async Task<Result> EditPower(EditPowerModel editPowerModel)

--- a/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
@@ -291,11 +291,11 @@ internal sealed class PowerRepository(
             .ToListAsync(cancellationToken);
         return powers.Count == ids.Count;
     }
-    
+
     public async Task AddPowerToFactionLevel(int powerId, int targetId)
     {
-        await context.FactionLevels
-            .Where(x => x.Id == targetId)
+        await context
+            .FactionLevels.Where(x => x.Id == targetId)
             .ExecuteUpdateAsync(x => x.SetProperty(y => y.PowerId, powerId));
     }
 }

--- a/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
+++ b/api/ExpressedRealms.Powers.Repository/Powers/PowerRepository.cs
@@ -291,4 +291,11 @@ internal sealed class PowerRepository(
             .ToListAsync(cancellationToken);
         return powers.Count == ids.Count;
     }
+    
+    public async Task AddPowerToFactionLevel(int powerId, int targetId)
+    {
+        await context.FactionLevels
+            .Where(x => x.Id == targetId)
+            .ExecuteUpdateAsync(x => x.SetProperty(y => y.PowerId, powerId));
+    }
 }

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModel.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModel.cs
@@ -1,9 +1,9 @@
-namespace ExpressedRealms.Powers.Repository.Powers.DTOs.PowerCreate;
+namespace ExpressedRealms.Powers.UseCases.Powers.CreatePower;
 
 public class CreatePowerModel
 {
     public required string Name { get; set; }
-    public List<int>? Category { get; set; }
+    public List<int> Category { get; set; } = new();
     public required string Description { get; set; }
     public required string GameMechanicEffect { get; set; }
     public string? Limitation { get; set; }

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModel.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModel.cs
@@ -2,6 +2,8 @@ namespace ExpressedRealms.Powers.UseCases.Powers.CreatePower;
 
 public class CreatePowerModel
 {
+    public CreatePowerTarget Target { get; set; }
+    public int TargetId { get; set; }
     public required string Name { get; set; }
     public List<int> Category { get; set; } = new();
     public required string Description { get; set; }
@@ -12,7 +14,6 @@ public class CreatePowerModel
     public int PowerLevel { get; set; }
     public byte PowerActivationType { get; set; }
     public string? Other { get; set; }
-    public int PowerPathId { get; set; }
     public bool IsPowerUse { get; set; }
     public string? Cost { get; set; }
 }

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
@@ -2,7 +2,7 @@ using ExpressedRealms.DB;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 
-namespace ExpressedRealms.Powers.Repository.Powers.DTOs.PowerCreate;
+namespace ExpressedRealms.Powers.UseCases.Powers.CreatePower;
 
 public class CreatePowerModelValidator : AbstractValidator<CreatePowerModel>
 {

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
@@ -74,7 +74,7 @@ public class CreatePowerModelValidator : AbstractValidator<CreatePowerModel>
             )
             .WithMessage("This is not a valid Power Activation Type");
 
-        RuleFor(x => x.PowerPathId)
+        RuleFor(x => x.TargetId)
             .MustAsync(
                 async (powerPathId, cancellationToken) =>
                 {

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
@@ -86,13 +86,11 @@ public class CreatePowerModelValidator : AbstractValidator<CreatePowerModel>
                                 x => x.Id == model.TargetId,
                                 cancellationToken
                             );
-                            break;
                         case CreatePowerTarget.FactionLevel:
                             return await dbContext.FactionLevels.AnyAsync(
                                 x => x.Id == model.TargetId,
                                 cancellationToken
                             );
-                            break;
                         default:
                             throw new InvalidEnumArgumentException(
                                 nameof(model.Target),

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using ExpressedRealms.DB;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
@@ -74,17 +75,35 @@ public class CreatePowerModelValidator : AbstractValidator<CreatePowerModel>
             )
             .WithMessage("This is not a valid Power Activation Type");
 
-        RuleFor(x => x.TargetId)
+        RuleFor(x => x)
             .MustAsync(
-                async (powerPathId, cancellationToken) =>
+                async (model, cancellationToken) =>
                 {
-                    return await dbContext.PowerPaths.AnyAsync(
-                        x => x.Id == powerPathId,
-                        cancellationToken
-                    );
+                    switch (model.Target)
+                    {
+                        case CreatePowerTarget.PowerPath:
+                            return await dbContext.PowerPaths.AnyAsync(
+                                x => x.Id == model.TargetId,
+                                cancellationToken
+                            );
+                            break;
+                        case CreatePowerTarget.FactionLevel:
+                            return await dbContext.FactionLevels.AnyAsync(
+                                x => x.Id == model.TargetId,
+                                cancellationToken
+                            );
+                            break;
+                        default:
+                            throw new InvalidEnumArgumentException(
+                                nameof(model.Target),
+                                (int)model.Target,
+                                typeof(CreatePowerTarget)
+                            );
+                    }
+
                 }
             )
             .WithErrorCode("NotFound")
-            .WithMessage("This is not a valid Power Path");
+            .WithMessage("This is not a valid Id for the given target");
     }
 }

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerModelValidator.cs
@@ -100,7 +100,6 @@ public class CreatePowerModelValidator : AbstractValidator<CreatePowerModel>
                                 typeof(CreatePowerTarget)
                             );
                     }
-
                 }
             )
             .WithErrorCode("NotFound")

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerTarget.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerTarget.cs
@@ -3,5 +3,5 @@ namespace ExpressedRealms.Powers.UseCases.Powers.CreatePower;
 public enum CreatePowerTarget
 {
     PowerPath = 1,
-    FactionLevel = 2
+    FactionLevel = 2,
 }

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerTarget.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerTarget.cs
@@ -1,0 +1,7 @@
+namespace ExpressedRealms.Powers.UseCases.Powers.CreatePower;
+
+public enum CreatePowerTarget
+{
+    PowerPath = 1,
+    FactionLevel = 2
+}

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerUseCase.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerUseCase.cs
@@ -1,0 +1,60 @@
+using ExpressedRealms.DB.Models.Powers;
+using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
+using ExpressedRealms.Powers.Repository.PowerPaths;
+using ExpressedRealms.Powers.Repository.Powers;
+using ExpressedRealms.UseCases.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Powers.UseCases.Powers.CreatePower;
+
+internal sealed class CreatePowerUseCase(
+    IPowerRepository powerRepository,
+    IPowerPathRepository powerPathRepository,
+    CreatePowerModelValidator validator,
+    CancellationToken cancellationToken
+) : ICreatePowerUseCase
+{
+    public async Task<Result<int>> ExecuteAsync(CreatePowerModel model)
+    {
+        var result = await ValidationHelper.ValidateAndHandleErrorsAsync(
+            validator,
+            model,
+            cancellationToken
+        );
+
+        if (result.IsFailed)
+            return Result.Fail(result.Errors);
+
+        var newPower = new Power
+        {
+            Name = model.Name,
+            Description = model.Description,
+            LevelId = model.PowerLevel,
+            AreaOfEffectTypeId = model.AreaOfEffect,
+            ActivationTimingTypeId = model.PowerActivationType,
+            DurationId = model.PowerDuration,
+            IsPowerUse = model.IsPowerUse,
+            GameMechanicEffect = model.GameMechanicEffect,
+            Limitation = model.Limitation,
+            OtherFields = model.Other,
+            Cost = model.Cost,
+            CategoryMappings = model.Category.Select(x => new PowerCategoryMapping()
+            {
+                CategoryId = x,
+            }).ToList()
+        };
+
+        var powerId = await powerRepository.CreatePower(newPower);
+
+        await powerPathRepository.AddPowerToPowerPath(
+            new PowerPathPowerMapping()
+            {
+                PowerId = powerId,
+                PowerPathId = model.PowerPathId
+            });
+        
+        return Result.Ok(powerId);
+    }
+
+
+}

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerUseCase.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerUseCase.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using ExpressedRealms.DB.Models.Powers;
 using ExpressedRealms.DB.Models.Powers.PowerPathPowerMappingSetup;
 using ExpressedRealms.Powers.Repository.PowerPaths;
@@ -46,12 +47,26 @@ internal sealed class CreatePowerUseCase(
 
         var powerId = await powerRepository.CreatePower(newPower);
 
-        await powerPathRepository.AddPowerToPowerPath(
-            new PowerPathPowerMapping()
-            {
-                PowerId = powerId,
-                PowerPathId = model.PowerPathId
-            });
+        switch (model.Target)
+        {
+            case CreatePowerTarget.PowerPath:
+                await powerPathRepository.AddPowerToPowerPath(
+                    new PowerPathPowerMapping()
+                    {
+                        PowerId = powerId,
+                        PowerPathId = model.TargetId
+                    });
+                break;
+            case CreatePowerTarget.FactionLevel:
+                await powerRepository.AddPowerToFactionLevel(powerId, model.TargetId);
+                break;
+            default:
+                throw new InvalidEnumArgumentException(
+                    nameof(model.Target),
+                    (int)model.Target,
+                    typeof(CreatePowerTarget)
+                );
+        }
         
         return Result.Ok(powerId);
     }

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerUseCase.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/CreatePowerUseCase.cs
@@ -39,10 +39,9 @@ internal sealed class CreatePowerUseCase(
             Limitation = model.Limitation,
             OtherFields = model.Other,
             Cost = model.Cost,
-            CategoryMappings = model.Category.Select(x => new PowerCategoryMapping()
-            {
-                CategoryId = x,
-            }).ToList()
+            CategoryMappings = model
+                .Category.Select(x => new PowerCategoryMapping() { CategoryId = x })
+                .ToList(),
         };
 
         var powerId = await powerRepository.CreatePower(newPower);
@@ -51,11 +50,8 @@ internal sealed class CreatePowerUseCase(
         {
             case CreatePowerTarget.PowerPath:
                 await powerPathRepository.AddPowerToPowerPath(
-                    new PowerPathPowerMapping()
-                    {
-                        PowerId = powerId,
-                        PowerPathId = model.TargetId
-                    });
+                    new PowerPathPowerMapping() { PowerId = powerId, PowerPathId = model.TargetId }
+                );
                 break;
             case CreatePowerTarget.FactionLevel:
                 await powerRepository.AddPowerToFactionLevel(powerId, model.TargetId);
@@ -67,9 +63,7 @@ internal sealed class CreatePowerUseCase(
                     typeof(CreatePowerTarget)
                 );
         }
-        
+
         return Result.Ok(powerId);
     }
-
-
 }

--- a/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/ICreatePowerUseCase.cs
+++ b/api/ExpressedRealms.Powers.UseCases/Powers/CreatePower/ICreatePowerUseCase.cs
@@ -1,0 +1,6 @@
+using ExpressedRealms.Shared;
+using FluentResults;
+
+namespace ExpressedRealms.Powers.UseCases.Powers.CreatePower;
+
+public interface ICreatePowerUseCase : IGenericUseCase<Result<int>, CreatePowerModel> { }

--- a/client/src/components/expressions/factions/FactionItem.vue
+++ b/client/src/components/expressions/factions/FactionItem.vue
@@ -3,13 +3,22 @@
 import { onMounted, type PropType, ref } from 'vue'
 import Card from 'primevue/card'
 import { ConfirmationPopup } from './services/confirmationPopupService'
-import { userPermissionStore } from '@/stores/userPermissionStore.ts'
+import { can, userPermissionStore } from '@/stores/userPermissionStore.ts'
 import type { Faction } from '@/components/expressions/factions/types.ts'
 import { factionDialogs } from '@/components/expressions/factions/services/dialogs.ts'
 import CommandButton, { type Command } from '@/uiComponents/CommandButton.vue'
+import { powerDialogs } from '@/components/expressions/powers/services/dialogs.ts'
+import { TargetPowerType } from '@/components/expressions/powers/types.ts'
+import Button from 'primevue/button'
+import { useQueryWithLoading } from '@/utilities/queryOverride.ts'
+import { factionListQuery } from '@/components/expressions/factions/stores/factionStore.ts'
+import { expressionStore } from '@/stores/expressionStore.ts'
 
 const userPermissionInfo = userPermissionStore()
 const permissionCheck = userPermissionInfo.permissionCheck
+
+const dialogs = powerDialogs()
+const expressionData = expressionStore()
 
 const props = defineProps({
   item: {
@@ -21,9 +30,23 @@ const props = defineProps({
 let popups = ConfirmationPopup(props.item.id, props.item.name)
 let editItemPopup = factionDialogs()
 
+const { refetch } = useQueryWithLoading(factionListQuery(expressionData.currentExpressionId))
+
 const items = ref<Command[]>([])
 
 onMounted(async () => {
+  PopulateFactionActions()
+})
+
+const showAddPower = async (levelId: number) => {
+  const result = await dialogs.showAddPower({ target: TargetPowerType.FactionLevel, targetId: levelId })
+
+  if (result?.action == 'added') {
+    await refetch()
+  }
+}
+
+function PopulateFactionActions() {
   if (permissionCheck.Faction.Edit) {
     items.value.push({
       label: 'Edit',
@@ -42,7 +65,7 @@ onMounted(async () => {
       severity: 'danger',
     })
   }
-})
+}
 
 </script>
 
@@ -70,7 +93,21 @@ onMounted(async () => {
         <div v-else>
           <p>Knowledge in {{ level.knowledge }} at a {{ level.knowledgeLevel }} level with a specialization in {{ level.specialization }}.</p>
         </div>
-        <h2>Rank Power</h2>
+        <div class="d-flex flex-column flex-md-row align-self-center justify-content-between mt-3">
+          <h3 class="p-0 m-0 flex-fill">
+            Rank Power
+          </h3>
+          <div class="p-0 m-0 d-inline-flex align-items-start">
+            <Button
+              v-if="can.Faction.Edit && !level.powerId" class="w-100 m-2"
+              label="Add Power" size="small" @click="showAddPower(level.id)"
+            />
+            <Button
+              v-if="can.Faction.Edit && level.powerId" class="w-100 m-2"
+              label="Edit Power" size="small" disabled
+            />
+          </div>
+        </div>
         <div>
           Fancy Power Info
         </div>

--- a/client/src/components/expressions/factions/types.ts
+++ b/client/src/components/expressions/factions/types.ts
@@ -12,13 +12,14 @@ export interface Faction {
 }
 
 export interface FactionLevel {
-  id?: number | string
+  id: number
   rankName: string
   knowledgeId?: number | string | null
   knowledge?: string | null
   knowledgeLevel?: string | null
   specialization?: string | null
   knowledgeLevelId?: number | string | null
+  powerId?: number | null
 }
 
 export interface EditSingleFactionInfo {

--- a/client/src/components/expressions/powers/AddPower.vue
+++ b/client/src/components/expressions/powers/AddPower.vue
@@ -4,7 +4,7 @@ import FormDropdownWrapper from '@/FormWrappers/FormDropdownWrapper.vue'
 import FormEditorWrapper from '@/FormWrappers/FormEditorWrapper.vue'
 import FormInputTextWrapper from '@/FormWrappers/FormInputTextWrapper.vue'
 import Button from 'primevue/button'
-import { onBeforeMount, type PropType, ref } from 'vue'
+import { inject, onBeforeMount, ref } from 'vue'
 import axios from 'axios'
 import toaster from '@/services/Toasters'
 import { getValidationInstance } from '@/components/expressions/powers/Validations/PowerValidations'
@@ -12,25 +12,12 @@ import FormCheckboxWrapper from '@/FormWrappers/FormCheckboxWrapper.vue'
 import FormMultiSelectWrapper from '@/FormWrappers/FormMultiSelectWrapper.vue'
 import { powersStore } from '@/components/expressions/powers/stores/powersStore'
 import PowerPrerequisites from '@/components/expressions/powers/PowerPrerequisites.vue'
-import { TargetPowerType } from '@/components/expressions/powers/types.ts'
+import { type AddPowerType, TargetPowerType } from '@/components/expressions/powers/types.ts'
+import type { DialogRef } from '@/utilities/dialogUtilities.ts'
 
 const form = getValidationInstance()
 
-const emit = defineEmits<{
-  cancelled: []
-  updated: []
-}>()
-
-const props = defineProps({
-  target: {
-    type: Object as PropType<TargetPowerType>,
-    required: true,
-  },
-  targetId: {
-    type: Number,
-    required: true,
-  },
-})
+const dialogRef = inject('dialogRef') as DialogRef<AddPowerType>
 
 const powers = powersStore()
 const prerequisiteChild = ref()
@@ -41,8 +28,8 @@ onBeforeMount(async () => {
 
 const onSubmit = form.handleSubmit(async (values) => {
   await axios.post(`/powers`, {
-    target: props.target,
-    targetId: props.targetId,
+    target: dialogRef.value.data.target,
+    targetId: dialogRef.value.data.targetId,
     name: values.name,
     description: values.description,
     gameMechanicEffect: values.gameMechanicEffect,
@@ -58,10 +45,12 @@ const onSubmit = form.handleSubmit(async (values) => {
   })
     .then(async (response) => {
       const newPowerId = response.data
-      if (props.target === TargetPowerType.PowerPath) {
+      if (dialogRef.value.data.target === TargetPowerType.PowerPath) {
         await prerequisiteChild.value.addUpdatePrerequisite(newPowerId)
       }
-      emit('updated')
+      dialogRef.value.close({
+        action: 'added',
+      })
       toaster.success('Successfully Added Power!')
       reset()
     })
@@ -69,7 +58,9 @@ const onSubmit = form.handleSubmit(async (values) => {
 
 const reset = () => {
   form.customResetForm()
-  emit('cancelled')
+  dialogRef.value.close({
+    action: 'cancelled',
+  })
 }
 
 </script>
@@ -121,7 +112,7 @@ const reset = () => {
 
       <FormEditorWrapper v-model="form.other" />
 
-      <PowerPrerequisites v-if="props.target === TargetPowerType.PowerPath" ref="prerequisiteChild" :power-path-id="props.targetId" />
+      <PowerPrerequisites v-if="dialogRef.data.target === TargetPowerType.PowerPath" ref="prerequisiteChild" :power-path-id="dialogRef.data.targetId" />
 
       <div class="float-end">
         <Button label="Cancel" class="m-2" type="reset" @click="reset" />

--- a/client/src/components/expressions/powers/AddPower.vue
+++ b/client/src/components/expressions/powers/AddPower.vue
@@ -4,7 +4,7 @@ import FormDropdownWrapper from '@/FormWrappers/FormDropdownWrapper.vue'
 import FormEditorWrapper from '@/FormWrappers/FormEditorWrapper.vue'
 import FormInputTextWrapper from '@/FormWrappers/FormInputTextWrapper.vue'
 import Button from 'primevue/button'
-import { onBeforeMount, ref } from 'vue'
+import { onBeforeMount, type PropType, ref } from 'vue'
 import axios from 'axios'
 import toaster from '@/services/Toasters'
 import { getValidationInstance } from '@/components/expressions/powers/Validations/PowerValidations'
@@ -12,15 +12,21 @@ import FormCheckboxWrapper from '@/FormWrappers/FormCheckboxWrapper.vue'
 import FormMultiSelectWrapper from '@/FormWrappers/FormMultiSelectWrapper.vue'
 import { powersStore } from '@/components/expressions/powers/stores/powersStore'
 import PowerPrerequisites from '@/components/expressions/powers/PowerPrerequisites.vue'
+import { TargetPowerType } from '@/components/expressions/powers/types.ts'
 
 const form = getValidationInstance()
 
 const emit = defineEmits<{
   cancelled: []
+  updated: []
 }>()
 
 const props = defineProps({
-  powerPathId: {
+  target: {
+    type: Object as PropType<TargetPowerType>,
+    required: true,
+  },
+  targetId: {
     type: Number,
     required: true,
   },
@@ -35,7 +41,8 @@ onBeforeMount(async () => {
 
 const onSubmit = form.handleSubmit(async (values) => {
   await axios.post(`/powers`, {
-    powerPathId: props.powerPathId,
+    target: props.target,
+    targetId: props.targetId,
     name: values.name,
     description: values.description,
     gameMechanicEffect: values.gameMechanicEffect,
@@ -51,8 +58,10 @@ const onSubmit = form.handleSubmit(async (values) => {
   })
     .then(async (response) => {
       const newPowerId = response.data
-      await prerequisiteChild.value.addUpdatePrerequisite(newPowerId)
-      await powers.updatePowersByPathId(props.powerPathId)
+      if (props.target === TargetPowerType.PowerPath) {
+        await prerequisiteChild.value.addUpdatePrerequisite(newPowerId)
+      }
+      emit('updated')
       toaster.success('Successfully Added Power!')
       reset()
     })
@@ -112,7 +121,7 @@ const reset = () => {
 
       <FormEditorWrapper v-model="form.other" />
 
-      <PowerPrerequisites ref="prerequisiteChild" :power-path-id="props.powerPathId" />
+      <PowerPrerequisites v-if="props.target === TargetPowerType.PowerPath" ref="prerequisiteChild" :power-path-id="props.targetId" />
 
       <div class="float-end">
         <Button label="Cancel" class="m-2" type="reset" @click="reset" />

--- a/client/src/components/expressions/powers/ListPowers.vue
+++ b/client/src/components/expressions/powers/ListPowers.vue
@@ -4,9 +4,12 @@ import AddPower from '@/components/expressions/powers/AddPower.vue'
 import PowerCard from '@/components/expressions/powers/PowerCard.vue'
 import Button from 'primevue/button'
 
-import type { Power } from '@/components/expressions/powers/types'
+import { type Power, TargetPowerType } from '@/components/expressions/powers/types'
 import PowerReorder from '@/components/expressions/powers/PowerReorder.vue'
 import { can } from '@/stores/userPermissionStore.ts'
+import { powersStore } from '@/components/expressions/powers/stores/powersStore.ts'
+
+const powerInfo = powersStore()
 
 const props = defineProps({
   powerPathId: {
@@ -34,6 +37,10 @@ const toggleReadOnly = () => {
   readOnly.value = !readOnly.value
 }
 
+const updatePowerPaths = async () => {
+  await powerInfo.updatePowersByPathId(props.powerPathId)
+}
+
 </script>
 
 <template>
@@ -45,8 +52,8 @@ const toggleReadOnly = () => {
   </div>
 
   <AddPower
-    v-if="showAddPower && can.Powers.Create && (!props.isReadOnly || !readOnly)"
-    :power-path-id="props.powerPathId" @cancelled="toggleAddPower"
+    v-if="showAddPower && can.Powers.Create && (!props.isReadOnly || !readOnly)" :target="TargetPowerType.PowerPath"
+    :target-id="props.powerPathId" @cancelled="toggleAddPower" @updated="updatePowerPaths"
   />
   <Button
     v-if="!showAddPower && can.Powers.Create && (!props.isReadOnly || !readOnly)" class="w-100 m-2"

--- a/client/src/components/expressions/powers/ListPowers.vue
+++ b/client/src/components/expressions/powers/ListPowers.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import AddPower from '@/components/expressions/powers/AddPower.vue'
 import PowerCard from '@/components/expressions/powers/PowerCard.vue'
 import Button from 'primevue/button'
 
@@ -8,8 +7,11 @@ import { type Power, TargetPowerType } from '@/components/expressions/powers/typ
 import PowerReorder from '@/components/expressions/powers/PowerReorder.vue'
 import { can } from '@/stores/userPermissionStore.ts'
 import { powersStore } from '@/components/expressions/powers/stores/powersStore.ts'
+import { powerDialogs } from '@/components/expressions/powers/services/dialogs.ts'
 
 const powerInfo = powersStore()
+
+const dialogs = powerDialogs()
 
 const props = defineProps({
   powerPathId: {
@@ -26,19 +28,17 @@ const props = defineProps({
   },
 })
 
-const showAddPower = ref(false)
-
-const toggleAddPower = () => {
-  showAddPower.value = !showAddPower.value
-}
-
 const readOnly = ref(false)
 const toggleReadOnly = () => {
   readOnly.value = !readOnly.value
 }
 
-const updatePowerPaths = async () => {
-  await powerInfo.updatePowersByPathId(props.powerPathId)
+const showAddPower = async () => {
+  const result = await dialogs.showAddPower({ target: TargetPowerType.PowerPath, targetId: props.powerPathId })
+
+  if (result?.action == 'added') {
+    await powerInfo.updatePowersByPathId(props.powerPathId)
+  }
 }
 
 </script>
@@ -51,12 +51,8 @@ const updatePowerPaths = async () => {
     </div>
   </div>
 
-  <AddPower
-    v-if="showAddPower && can.Powers.Create && (!props.isReadOnly || !readOnly)" :target="TargetPowerType.PowerPath"
-    :target-id="props.powerPathId" @cancelled="toggleAddPower" @updated="updatePowerPaths"
-  />
   <Button
-    v-if="!showAddPower && can.Powers.Create && (!props.isReadOnly || !readOnly)" class="w-100 m-2"
-    label="Add Power" @click="toggleAddPower"
+    v-if="can.Powers.Create && (!props.isReadOnly || !readOnly)" class="w-100 m-2"
+    label="Add Power" @click="showAddPower"
   />
 </template>

--- a/client/src/components/expressions/powers/services/dialogs.ts
+++ b/client/src/components/expressions/powers/services/dialogs.ts
@@ -1,0 +1,12 @@
+import { useAppDialog } from '@/utilities/dialogUtilities.ts'
+import type { AddPowerType } from '@/components/expressions/powers/types.ts'
+
+const AddPower = () => import('@/components/expressions/powers/AddPower.vue')
+
+export const powerDialogs = () => {
+  const dialog = useAppDialog()
+
+  return {
+    showAddPower: (data: AddPowerType) => dialog.open(AddPower, { header: 'Add Power', data }),
+  }
+}

--- a/client/src/components/expressions/powers/types.ts
+++ b/client/src/components/expressions/powers/types.ts
@@ -11,6 +11,11 @@ export enum TargetPowerType {
   FactionLevel = 2,
 }
 
+export interface AddPowerType {
+  target: TargetPowerType
+  targetId: number
+}
+
 export interface PowerStore {
   powerPathId: number
   powers: Power[]

--- a/client/src/components/expressions/powers/types.ts
+++ b/client/src/components/expressions/powers/types.ts
@@ -6,6 +6,11 @@ export interface DetailedInformation {
   id: number
 }
 
+export enum TargetPowerType {
+  PowerPath = 1,
+  FactionLevel = 2,
+}
+
 export interface PowerStore {
   powerPathId: number
   powers: Power[]

--- a/client/src/utilities/dialogUtilities.ts
+++ b/client/src/utilities/dialogUtilities.ts
@@ -1,0 +1,45 @@
+import { useDialog } from 'primevue/usedialog'
+import { type Component } from 'vue'
+
+type ComponentLoader = () => Promise<{ default: Component }>
+
+export const useAppDialog = () => {
+  const dialog = useDialog()
+
+  const open = async <TData, TResult = any>(
+    loader: ComponentLoader,
+    options: {
+      header: string
+      data: TData
+    },
+  ): Promise<TResult> => {
+    const component = (await loader()).default
+    return new Promise((resolve) => {
+      dialog.open(component, {
+        props: {
+          header: options.header,
+          style: {
+            width: '500px',
+          },
+          breakpoints: {
+            '960px': '75vw',
+            '640px': '90vw',
+          },
+          modal: true,
+        },
+        data: options.data,
+
+        onClose: (opts: any) => {
+          resolve(opts?.data)
+        },
+      })
+    })
+  }
+
+  return { open }
+}
+
+export type DialogRef<TData = any, TResult = any> = Ref<{
+  data: TData
+  close: (result?: TResult) => void
+}>

--- a/documentation/docs/dialogs.md
+++ b/documentation/docs/dialogs.md
@@ -1,0 +1,64 @@
+# Dialogs
+Dialogs are used to display edit / create behavior in the system.
+
+## Key Features
+ - Lazy Loading – useAppDialog will force the caller to use lazy loading till the action is called - saving initial load time
+ - Standardized dialog size – Provides a central location to define the size of dialogs
+
+## Location
+
+The main location is [client/utilities/dialogUtilities.ts](./../../client/utilities/dialogUtilities.ts)
+
+## Setup
+
+dailog.ts
+```ts
+
+import { useAppDialog } from '@/utilities/dialogUtilities.ts'
+import type { AddPowerType } from '@/components/expressions/powers/types.ts'
+
+const AddPower = () => import('@/components/expressions/powers/AddPower.vue')
+
+export const powerDialogs = () => {
+  const dialog = useAppDialog()
+
+  return {
+    showAddPower: (data: AddPowerType) => dialog.open(AddPower, { header: 'Add Power', data }),
+  }
+}
+
+```
+
+### Component Usage
+
+```ts
+import type { DialogRef } from '@/utilities/dialogUtilities.ts'
+
+const dialogRef = inject('dialogRef') as DialogRef<AddPowerType>
+
+const values = {
+  target: dialogRef.value.data.target,
+  targetId: dialogRef.value.data.targetId,
+}
+
+const reset = () => {
+  form.customResetForm()
+  dialogRef.value.close({
+    action: 'cancelled', // or 'added", etc
+  })
+}
+```
+
+### Caller Usage
+
+```ts
+const dialogs = powerDialogs()
+
+const showAddPower = async () => {
+  const result = await dialogs.showAddPower({ target: TargetPowerType.PowerPath, targetId: props.powerPathId })
+
+  if (result?.action == 'added') {
+    await powerInfo.updatePowersByPathId(props.powerPathId)
+  }
+}
+```

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
   - Creating GPG Keys: creatingGPGKeys.md
   - Cypress: cypress.md
   - Database: database.md
+  - Dialogs: dialogs.md
   - Discord Support: discordSupport.md
   - Docker / Podman: docker-podman.md
   - EF Core Practices: efCorePractices.md


### PR DESCRIPTION
 - Create Power Logic now in Use Case + Refactored
 - Faction Levels now have Power Ids
 - Create Power Use Case now handles Faction Levels
 - UI update to allow addition of Powers - Can't see it - saving for later PR
 - Standardized Dialog Popups
   - Centralized common logic
   - Will now force lazy loading of components
   - Created general way of returning dialog actions