### PR TITLE
Add Basic Character Faction UI

### DIFF
--- a/api/ExpressedRealms.Expressions.API/CharacterFactionEndpoints/GetFactions/FactionResponse.cs
+++ b/api/ExpressedRealms.Expressions.API/CharacterFactionEndpoints/GetFactions/FactionResponse.cs
@@ -3,4 +3,5 @@ namespace ExpressedRealms.Expressions.API.CharacterFactionEndpoints.GetFactions;
 public class FactionResponse
 {
     public List<FactionLevelModel> FactionLevels { get; set; } = new();
+    public int? FactionId { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.API/CharacterFactionEndpoints/GetFactions/GetCharacterFactionsEndpoint.cs
+++ b/api/ExpressedRealms.Expressions.API/CharacterFactionEndpoints/GetFactions/GetCharacterFactionsEndpoint.cs
@@ -31,6 +31,7 @@ public static class GetCharacterFactionsEndpoint
                         CharacterNotes = x.CharacterNotes,
                     })
                     .ToList(),
+                FactionId = results.Value.FactionId
             }
         );
     }

--- a/api/ExpressedRealms.Expressions.Repository/CharacterFactions/CharacterFactionRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/CharacterFactions/CharacterFactionRepository.cs
@@ -42,6 +42,7 @@ internal sealed class CharacterFactionRepository(
     {
         var factionId = await context
             .CharacterFactionMappings.Where(x => x.CharacterId == characterId)
+            .OrderBy(x => x.ApprovalDate)
             .Select(x => new { x.FactionLevel.FactionId })
             .FirstOrDefaultAsync(cancellationToken);
 

--- a/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/CharacterFaction/GetCharacterFactionLevelsUseCaseTests.cs
+++ b/api/ExpressedRealms.Expressions.UseCases.Tests.Unit/CharacterFaction/GetCharacterFactionLevelsUseCaseTests.cs
@@ -34,6 +34,9 @@ public class GetCharacterFactionLevelsUseCaseTests
         A.CallTo(() => _characterRepository.FindCharacterAsync(_model.CharacterId))
             .Returns(_character);
 
+        A.CallTo(() => _characterFactionRepository.GetPlayerFactionInfo(_model.CharacterId))
+            .Returns(new PlayerFactionInfoDto() { FactionId = 5 });
+        
         A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
             .Returns(new List<CharacterFactionDto>());
 
@@ -460,7 +463,7 @@ public class GetCharacterFactionLevelsUseCaseTests
     }
 
     [Fact]
-    public async Task UseCase_WillReturn_AllFactionLevels()
+    public async Task UseCase_WillReturn_AllFactionLevelsAndFactionId()
     {
         A.CallTo(() => _characterFactionRepository.GetFactionLevels(_model.CharacterId))
             .Returns(
@@ -474,6 +477,7 @@ public class GetCharacterFactionLevelsUseCaseTests
         var result = await _useCase.ExecuteAsync(_model);
 
         Assert.Equal(2, result.Value.FactionLevels.Count);
+        Assert.Equal(5, result.Value.FactionId);
         Assert.Contains(result.Value.FactionLevels, x => x.FactionLevelId == 7);
         Assert.Contains(result.Value.FactionLevels, x => x.FactionLevelId == 8);
     }

--- a/api/ExpressedRealms.Expressions.UseCases/CharacterFactionMapping/GetFactions/FactionsReturnModel.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/CharacterFactionMapping/GetFactions/FactionsReturnModel.cs
@@ -3,4 +3,5 @@ namespace ExpressedRealms.Expressions.UseCases.CharacterFactionMapping.GetFactio
 public class FactionsReturnModel
 {
     public List<CharacterFactionLevelInfo> FactionLevels { get; set; } = new();
+    public int? FactionId { get; set; }
 }

--- a/api/ExpressedRealms.Expressions.UseCases/CharacterFactionMapping/GetFactions/GetCharacterFactionLevelsUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/CharacterFactionMapping/GetFactions/GetCharacterFactionLevelsUseCase.cs
@@ -45,6 +45,8 @@ internal sealed class GetCharacterFactionLevelsUseCase(
             model.CharacterId
         );
 
+        var currentFaction = await characterFactionRepository.GetPlayerFactionInfo(model.CharacterId);
+
         return Result.Ok(
             new FactionsReturnModel()
             {
@@ -82,6 +84,7 @@ internal sealed class GetCharacterFactionLevelsUseCase(
                         return factionLevel;
                     })
                     .ToList(),
+                FactionId = currentFaction?.FactionId
             }
         );
     }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3778,9 +3778,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4618,9 +4618,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5578,9 +5578,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/client/src/components/characters/character/stores/characterStore.ts
+++ b/client/src/components/characters/character/stores/characterStore.ts
@@ -21,6 +21,7 @@ export const characterStore
         isOwner: false as boolean,
         factions: [] as any[],
         faction: {} as any,
+        characterId: 0 as number,
         canModifyPrimaryCharacter: false as boolean,
       }
     },
@@ -29,6 +30,7 @@ export const characterStore
         this.isLoading = false
         return await axios.get(`/characters/${characterId}`)
           .then(async (response) => {
+            this.characterId = characterId
             this.name = response.data.name
             this.background = response.data.background
             this.expression = response.data.expression

--- a/client/src/components/characters/wizard/CharacterWizard.vue
+++ b/client/src/components/characters/wizard/CharacterWizard.vue
@@ -20,6 +20,7 @@ import DisadvantageStep from '@/components/characters/wizard/blessings/Disadvant
 import ContactStep from '@/components/characters/wizard/contacts/ContactStep.vue'
 import { userPermissionStore } from '@/stores/userPermissionStore.ts'
 import FactionSelectList from '@/components/characters/wizard/factions/FactionSelectionList.vue'
+import { hasFlag } from '@/stores/featureFlags/featureFlagStore.ts'
 
 const xpData = experienceStore()
 const route = useRoute()
@@ -38,7 +39,7 @@ const sections = computed(() => [
   { name: 'Basic Info', component: isAdd.value ? markRaw(AddCharacter) : markRaw(EditCharacterDetails) },
   { name: 'Stats', isDisabled: isAdd.value, component: markRaw(StatStep) },
   { name: 'Skills', isDisabled: isAdd.value, component: markRaw(SkillStep) },
-  { name: 'Faction', isDisabled: isAdd.value, component: markRaw(FactionSelectList) },
+  { name: 'Faction', isDisabled: isAdd.value, component: markRaw(FactionSelectList), visible: () => hasFlag.ShowFactions },
   { name: 'Powers', isDisabled: isAdd.value, component: markRaw(PowerStep) },
   { name: 'Knowledges', isDisabled: isAdd.value, component: markRaw(KnowledgeStep) },
   { name: 'Contacts', isDisabled: isAdd.value, visible: () => !characterInfo.isInCharacterCreation && !isAdd.value, component: markRaw(ContactStep) },

--- a/client/src/components/characters/wizard/CharacterWizard.vue
+++ b/client/src/components/characters/wizard/CharacterWizard.vue
@@ -19,6 +19,7 @@ import { characterStore } from '@/components/characters/character/stores/charact
 import DisadvantageStep from '@/components/characters/wizard/blessings/DisadvantageStep.vue'
 import ContactStep from '@/components/characters/wizard/contacts/ContactStep.vue'
 import { userPermissionStore } from '@/stores/userPermissionStore.ts'
+import FactionSelectList from '@/components/characters/wizard/factions/FactionSelectionList.vue'
 
 const xpData = experienceStore()
 const route = useRoute()
@@ -37,6 +38,7 @@ const sections = computed(() => [
   { name: 'Basic Info', component: isAdd.value ? markRaw(AddCharacter) : markRaw(EditCharacterDetails) },
   { name: 'Stats', isDisabled: isAdd.value, component: markRaw(StatStep) },
   { name: 'Skills', isDisabled: isAdd.value, component: markRaw(SkillStep) },
+  { name: 'Faction', isDisabled: isAdd.value, component: markRaw(FactionSelectList) },
   { name: 'Powers', isDisabled: isAdd.value, component: markRaw(PowerStep) },
   { name: 'Knowledges', isDisabled: isAdd.value, component: markRaw(KnowledgeStep) },
   { name: 'Contacts', isDisabled: isAdd.value, visible: () => !characterInfo.isInCharacterCreation && !isAdd.value, component: markRaw(ContactStep) },

--- a/client/src/components/characters/wizard/CharacterWizard.vue
+++ b/client/src/components/characters/wizard/CharacterWizard.vue
@@ -1,26 +1,49 @@
 <script setup lang="ts">
 import Button from 'primevue/button'
 import Card from 'primevue/card'
-import { computed, defineAsyncComponent, markRaw, onBeforeMount, ref, watch } from 'vue'
-import KnowledgeStep from '@/components/characters/wizard/knowledges/KnowledgeStep.vue'
+import { computed, defineAsyncComponent, onBeforeMount, ref, watch } from 'vue'
 import { experienceStore } from '@/components/characters/character/stores/experienceBreakdownStore.ts'
-import PowerStep from '@/components/characters/wizard/powers/PowerStep.vue'
-import StatStep from '@/components/characters/wizard/stats/StatStep.vue'
-import SkillStep from '@/components/characters/wizard/skills/SkillStep.vue'
 import { useRoute, useRouter } from 'vue-router'
-import EditCharacterDetails from '@/components/characters/wizard/basicInfo/EditCharacterDetails.vue'
-import AddCharacter from '@/components/characters/wizard/basicInfo/AddCharacter.vue'
 import WizardContent from '@/components/characters/wizard/WizardContent.vue'
 import { breakpointsBootstrapV5, useBreakpoints } from '@vueuse/core'
 import { wizardContentStore } from '@/components/characters/wizard/stores/wizardContentStore.ts'
-import ReviewCharacter from '@/components/characters/character/xp/ReviewCharacter.vue'
-import AdvantageStep from '@/components/characters/wizard/blessings/AdvantageStep.vue'
 import { characterStore } from '@/components/characters/character/stores/characterStore.ts'
-import DisadvantageStep from '@/components/characters/wizard/blessings/DisadvantageStep.vue'
-import ContactStep from '@/components/characters/wizard/contacts/ContactStep.vue'
 import { userPermissionStore } from '@/stores/userPermissionStore.ts'
-import FactionSelectList from '@/components/characters/wizard/factions/FactionSelectionList.vue'
 import { hasFlag } from '@/stores/featureFlags/featureFlagStore.ts'
+
+const BasicInfoStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/basicInfo/EditCharacterDetails.vue'),
+)
+const AddCharacterStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/basicInfo/AddCharacter.vue'),
+)
+const StatStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/stats/StatStep.vue'),
+)
+const SkillStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/skills/SkillStep.vue'),
+)
+const FactionSelectList = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/factions/FactionSelectionList.vue'),
+)
+const PowerStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/powers/PowerStep.vue'),
+)
+const KnowledgeStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/knowledges/KnowledgeStep.vue'),
+)
+const ContactStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/contacts/ContactStep.vue'),
+)
+const AdvantageStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/blessings/AdvantageStep.vue'),
+)
+const DisadvantageStep = defineAsyncComponent(() =>
+  import('@/components/characters/wizard/blessings/DisadvantageStep.vue'),
+)
+const ReviewCharacterStep = defineAsyncComponent(() =>
+  import('@/components/characters/character/xp/ReviewCharacter.vue'),
+)
 
 const xpData = experienceStore()
 const route = useRoute()
@@ -36,16 +59,16 @@ const isMobile = activeBreakpoint.smaller('md')
 const wizardContentData = wizardContentStore()
 
 const sections = computed(() => [
-  { name: 'Basic Info', component: isAdd.value ? markRaw(AddCharacter) : markRaw(EditCharacterDetails) },
-  { name: 'Stats', isDisabled: isAdd.value, component: markRaw(StatStep) },
-  { name: 'Skills', isDisabled: isAdd.value, component: markRaw(SkillStep) },
-  { name: 'Faction', isDisabled: isAdd.value, component: markRaw(FactionSelectList), visible: () => hasFlag.ShowFactions },
-  { name: 'Powers', isDisabled: isAdd.value, component: markRaw(PowerStep) },
-  { name: 'Knowledges', isDisabled: isAdd.value, component: markRaw(KnowledgeStep) },
-  { name: 'Contacts', isDisabled: isAdd.value, visible: () => !characterInfo.isInCharacterCreation && !isAdd.value, component: markRaw(ContactStep) },
-  { name: 'Advantages', isDisabled: isAdd.value, component: defineAsyncComponent(async () => AdvantageStep) },
-  { name: 'Disadvantages', isDisabled: isAdd.value, component: defineAsyncComponent(async () => DisadvantageStep) },
-  { name: 'Review Character', isDisabled: isAdd.value, component: markRaw(ReviewCharacter) },
+  { name: 'Basic Info', component: isAdd.value ? AddCharacterStep : BasicInfoStep },
+  { name: 'Stats', isDisabled: isAdd.value, component: StatStep },
+  { name: 'Skills', isDisabled: isAdd.value, component: SkillStep },
+  { name: 'Faction', isDisabled: isAdd.value, component: FactionSelectList, visible: () => hasFlag.ShowFactions },
+  { name: 'Powers', isDisabled: isAdd.value, component: PowerStep },
+  { name: 'Knowledges', isDisabled: isAdd.value, component: KnowledgeStep },
+  { name: 'Contacts', isDisabled: isAdd.value, visible: () => !characterInfo.isInCharacterCreation && !isAdd.value, component: ContactStep },
+  { name: 'Advantages', isDisabled: isAdd.value, component: AdvantageStep },
+  { name: 'Disadvantages', isDisabled: isAdd.value, component: DisadvantageStep },
+  { name: 'Review Character', isDisabled: isAdd.value, component: ReviewCharacterStep },
 ])
 
 onBeforeMount(async () => {

--- a/client/src/components/characters/wizard/CharacterWizard.vue
+++ b/client/src/components/characters/wizard/CharacterWizard.vue
@@ -51,6 +51,20 @@ onBeforeMount(async () => {
   await fetchData()
 })
 
+const routeSection = computed(() => {
+  const section = route.query.section
+
+  return typeof section === 'string' ? section : null
+})
+
+const visibleSections = computed(() =>
+  sections.value.filter(section => section.visible ? section.visible() : true),
+)
+
+const isValidRouteSection = computed(() =>
+  visibleSections.value.some(section => section.name === routeSection.value && !section.isDisabled),
+)
+
 async function fetchData() {
   if (!characterInfo.isOwner && !permissionCheck.Archetypes.Edit && !isAdd.value) {
     await router.push({ name: 'characterSheet', params: { id: Number.parseInt(route.params.id as string) } })
@@ -67,7 +81,10 @@ async function fetchData() {
 
     await xpData.getExperience(route.params.id)
 
-    if (!isMobile.value) {
+    if (isValidRouteSection.value) {
+      selectSection(routeSection.value!)
+    }
+    else if (!isMobile.value) {
       selectSection('Basic Info')
     }
   }
@@ -82,18 +99,42 @@ watch(
   },
 )
 
+watch(
+  () => route.query.section,
+  () => {
+    if (isValidRouteSection.value) {
+      selectedSection.value = routeSection.value!
+    }
+    else if (!routeSection.value) {
+      selectedSection.value = ''
+    }
+  },
+)
+
 const selectedSection = ref<string>('')
 const currentView = computed(() => sections.value.filter(x => x.name == selectedSection.value)[0].component)
 const hasSelectedSection = computed(() => selectedSection.value !== '')
 
-const selectSection = (name: string) => {
+const selectSection = async (name: string) => {
   wizardContentData.hideContent()
   selectedSection.value = name
+
+  await router.push({
+    query: {
+      ...route.query,
+      section: name,
+    },
+  })
 }
 
-const resetSection = () => {
+const resetSection = async () => {
   wizardContentData.hideContent()
   selectedSection.value = ''
+
+  const query = { ...route.query }
+  delete query.section
+
+  await router.replace({ query })
 }
 
 const redirectToEdit = () => {

--- a/client/src/components/characters/wizard/factions/CharacterFactionEdit.vue
+++ b/client/src/components/characters/wizard/factions/CharacterFactionEdit.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+
+import { onMounted, type PropType, ref } from 'vue'
+import Card from 'primevue/card'
+import Button from 'primevue/button'
+import type { Faction, FactionLevel } from '@/components/expressions/factions/types.ts'
+import CommandButton, { type Command } from '@/uiComponents/CommandButton.vue'
+import { TargetPowerType } from '@/components/expressions/powers/types.ts'
+import { useQueryWithLoading } from '@/utilities/queryOverride.ts'
+import { factionListQuery } from '@/components/expressions/factions/stores/factionStore.ts'
+import { expressionStore } from '@/stores/expressionStore.ts'
+import PowerCard from '@/components/expressions/powers/PowerCard.vue'
+import { characterStore } from '@/components/characters/character/stores/characterStore.ts'
+import { pickedFactionQuery, pickFaction } from '@/components/characters/wizard/factions/stores/factionStore.ts'
+import StatusIcon from '@/components/characters/wizard/factions/StatusIcon.vue'
+
+const expressionData = expressionStore()
+const characterInfo = characterStore()
+
+const props = defineProps({
+  item: {
+    type: Object as PropType<Faction>,
+    required: true,
+  },
+})
+
+const { refetch } = useQueryWithLoading(factionListQuery(expressionData.currentExpressionId))
+const { data, isLoading } = useQueryWithLoading(pickedFactionQuery(characterInfo.characterId))
+const items = ref<Command[]>([])
+
+onMounted(async () => {
+  PopulateFactionActions()
+})
+
+const modifiedPower = async () => {
+  await refetch()
+}
+
+function PopulateFactionActions() {
+  if (characterInfo.isOwner) {
+    items.value.push({
+      label: 'Leave',
+      severity: 'danger',
+      command: async ($event) => {
+        const action = pickFaction()
+        await action.mutateAsync({ data: { characterId: characterInfo.characterId, factionId: props.item.id } })
+      },
+    })
+  }
+}
+
+function lookupFactionLevel(level: FactionLevel) {
+  if (!data.value) return null
+  return data.value!.factionLevels.find(f => f.factionLevelId == level.id)
+}
+
+function showRequestPromotionButton(level: FactionLevel, previousLevel: FactionLevel) {
+  if (!data.value) return null
+  const currentLevel = data.value!.factionLevels.find(f => f.factionLevelId == level.id)
+  const previousLevelApproved = (data.value!.factionLevels.find(f => f.factionLevelId == previousLevel.id))?.approvalDate != null
+  return previousLevelApproved && currentLevel?.hasKnowledge && currentLevel?.hasKnowledgeLevel && currentLevel?.hasSpecialization
+}
+
+</script>
+
+<template>
+  <Card>
+    <template #content>
+      <div class="d-flex flex-column flex-md-row align-self-center justify-content-between">
+        <h1 class="p-0 m-0 flex-fill">
+          {{ props.item?.name }}
+        </h1>
+        <div class="p-0 m-0 d-inline-flex align-items-start">
+          <CommandButton :commands="items" />
+        </div>
+      </div>
+      <div class="p-0 m-0">
+        <div v-html="props.item.background" />
+      </div>
+
+      <div v-for="(level, index) in props.item.factionLevels" :key="level.id">
+        <h2>{{ level.rankName }} Rank</h2>
+        <h3>Requirements:</h3>
+        <div v-if="level.rankName == 'Basic'">
+          No Requirements to join
+        </div>
+        <div v-else>
+          <div>
+            <div><StatusIcon :value="lookupFactionLevel(props.item.factionLevels[index -1])?.approvalDate" /> - {{ props.item.factionLevels[index -1].rankName }} Rank </div>
+            <div><StatusIcon :value="lookupFactionLevel(level)?.hasKnowledge" /> -  Knowledge "{{ level.knowledge }}"</div>
+            <div><StatusIcon :value="lookupFactionLevel(level)?.hasKnowledgeLevel" /> - Knowledge Level of "{{ level.knowledgeLevel }}" </div>
+            <div><StatusIcon :value="lookupFactionLevel(level)?.hasSpecialization" /> -  Specialization in "{{ level.specialization }}"</div>
+          </div>
+          <div v-if="showRequestPromotionButton(level, props.item.factionLevels[index -1])">
+            <Button :label="`Request Promotion to ${level.rankName} Rank`" severity="primary" class="w-100 mt-3" />
+          </div>
+        </div>
+
+        <PowerCard
+          v-if="level.power" :target-type="TargetPowerType.FactionLevel" :power="level.power" :power-path-id="-1" :starting-header="3"
+          @modified="modifiedPower"
+        />
+        <div v-else class="pt-3">
+          No Known Powers for this rank
+        </div>
+      </div>
+    </template>
+  </Card>
+</template>

--- a/client/src/components/characters/wizard/factions/FactionItem.vue
+++ b/client/src/components/characters/wizard/factions/FactionItem.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+
+import { onMounted, type PropType, ref } from 'vue'
+import Card from 'primevue/card'
+import type { Faction } from '@/components/expressions/factions/types.ts'
+import CommandButton, { type Command } from '@/uiComponents/CommandButton.vue'
+import { TargetPowerType } from '@/components/expressions/powers/types.ts'
+import { useQueryWithLoading } from '@/utilities/queryOverride.ts'
+import { factionListQuery } from '@/components/expressions/factions/stores/factionStore.ts'
+import { expressionStore } from '@/stores/expressionStore.ts'
+import PowerCard from '@/components/expressions/powers/PowerCard.vue'
+import { characterStore } from '@/components/characters/character/stores/characterStore.ts'
+import { pickFaction } from '@/components/characters/wizard/factions/stores/factionStore.ts'
+
+const expressionData = expressionStore()
+const characterInfo = characterStore()
+
+const props = defineProps({
+  item: {
+    type: Object as PropType<Faction>,
+    required: true,
+  },
+})
+
+const { refetch } = useQueryWithLoading(factionListQuery(expressionData.currentExpressionId))
+const items = ref<Command[]>([])
+
+onMounted(async () => {
+  PopulateFactionActions()
+})
+
+const modifiedPower = async () => {
+  await refetch()
+}
+
+function PopulateFactionActions() {
+  if (characterInfo.isOwner) {
+    items.value.push({
+      label: 'Select',
+      severity: 'primary',
+      command: async ($event) => {
+        const action = pickFaction()
+        await action.mutateAsync({ data: { characterId: characterInfo.characterId, factionId: props.item.id } })
+      },
+    })
+  }
+}
+
+function article(value: string): 'A' | 'An' {
+  return /^[aeiou]/i.test(value) ? 'An' : 'A'
+}
+
+</script>
+
+<template>
+  <Card>
+    <template #content>
+      <div class="d-flex flex-column flex-md-row align-self-center justify-content-between">
+        <h1 class="p-0 m-0 flex-fill">
+          {{ props.item?.name }}
+        </h1>
+        <div class="p-0 m-0 d-inline-flex align-items-start">
+          <CommandButton :commands="items" />
+        </div>
+      </div>
+      <div class="p-0 m-0">
+        <div v-html="props.item.background" />
+      </div>
+
+      <div v-for="level in props.item.factionLevels" :key="level.id">
+        <h2>{{ level.rankName }} Rank</h2>
+        <h3>Requirements:</h3>
+        <div v-if="level.rankName == 'Basic'">
+          No Requirements to join
+        </div>
+        <div v-else>
+          <ul>
+            <li>{{ article(level.knowledgeLevel) }} "{{ level.knowledgeLevel }}" level in the "{{ level.knowledge }}" knowledge</li>
+            <li>Specialization in "{{ level.specialization }}" for above knowledge</li>
+            <li>GO approval with the completion of one or more tasks / trials</li>
+          </ul>
+        </div>
+        <PowerCard
+          v-if="level.power" :target-type="TargetPowerType.FactionLevel" :power="level.power" :power-path-id="-1" :starting-header="3"
+          @modified="modifiedPower"
+        />
+        <div v-else>
+          No Known Powers for this rank
+        </div>
+      </div>
+    </template>
+  </Card>
+</template>

--- a/client/src/components/characters/wizard/factions/FactionSelectionList.vue
+++ b/client/src/components/characters/wizard/factions/FactionSelectionList.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+
+import Card from 'primevue/card'
+import Skeleton from 'primevue/skeleton'
+import { useQueryWithLoading } from '@/utilities/queryOverride.ts'
+import { factionListQuery } from '@/components/expressions/factions/stores/factionStore.ts'
+import { characterStore } from '@/components/characters/character/stores/characterStore.ts'
+import { computed } from 'vue'
+import FactionItem from '@/components/characters/wizard/factions/FactionItem.vue'
+import { pickedFactionQuery } from '@/components/characters/wizard/factions/stores/factionStore.ts'
+import CharacterFactionEdit from '@/components/characters/wizard/factions/CharacterFactionEdit.vue'
+
+const characterInfo = characterStore()
+
+const { data, isLoading, error } = useQueryWithLoading(factionListQuery(characterInfo.expressionId))
+
+const { data: characterData, isLoading: characterDataLoading } = useQueryWithLoading(pickedFactionQuery(characterInfo.characterId))
+
+const selectedFaction = computed(() => {
+  if (characterData.value?.factionId) {
+    return data.value?.factions.find(
+      faction => faction.id === characterData.value!.factionId,
+    )
+  }
+  return null
+})
+</script>
+
+<template>
+  <div>
+    <p>All players are encouraged to join a faction, as you get a free power.  These are completely optional, and you can only join one at a time.</p>
+    <p>Each rank has a requirement in terms of a knowledge you need to know, and you also need to complete one or more quests to level up.</p>
+  </div>
+  <div v-if="isLoading || characterDataLoading">
+    <Skeleton v-for="height in 3" :key="height" class="mb-3 mt-3" height="100px" />
+  </div>
+  <div v-else-if="error">
+    <Card>
+      <template #title>
+        Error Loading Factions
+      </template>
+      <template #content>
+        Please try again, or open an issue on discord
+      </template>
+    </Card>
+  </div>
+  <div v-else-if="data && data.factions.length === 0">
+    <Card>
+      <template #title>
+        No Factions
+      </template>
+      <template #content>
+        <p>
+          There are no known factions for this expression
+        </p>
+      </template>
+    </Card>
+  </div>
+  <div v-if="selectedFaction">
+    <CharacterFactionEdit :item="selectedFaction" />
+  </div>
+  <div v-else>
+    <div v-for="item in data?.factions" :key="item.id">
+      <FactionItem :item="item" />
+    </div>
+  </div>
+</template>

--- a/client/src/components/characters/wizard/factions/StatusIcon.vue
+++ b/client/src/components/characters/wizard/factions/StatusIcon.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineProps<{
+  value: boolean | null | undefined
+}>()
+</script>
+
+<template>
+  <span>{{ value ? '✅' : '❌' }}</span>
+</template>

--- a/client/src/components/characters/wizard/factions/services/confirmationPopupService.ts
+++ b/client/src/components/characters/wizard/factions/services/confirmationPopupService.ts
@@ -1,0 +1,28 @@
+import { useConfirm } from 'primevue/useconfirm'
+import { useDeleteFaction } from '@/components/expressions/factions/stores/factionStore.ts'
+
+export const ConfirmationPopup = (id: number, name: string) => {
+  const confirm = useConfirm()
+  const { mutate: deleteFaction } = useDeleteFaction()
+  const deleteConfirmation = (event: MouseEvent) =>
+    confirm.require({
+      target: event.target as HTMLElement,
+      group: 'popup',
+      message: `Do you want to delete ${name}?`,
+      icon: 'pi pi-info-circle',
+      rejectProps: {
+        label: 'Cancel',
+        severity: 'secondary',
+        outlined: true,
+      },
+      acceptProps: {
+        label: 'Delete Archetype',
+        severity: 'danger',
+      },
+      accept: () => {
+        deleteFaction(id)
+      },
+    })
+
+  return { deleteConfirmation }
+}

--- a/client/src/components/characters/wizard/factions/services/dialogs.ts
+++ b/client/src/components/characters/wizard/factions/services/dialogs.ts
@@ -1,0 +1,48 @@
+import { useDialog } from 'primevue/usedialog'
+import FactionEdit from '@/components/expressions/factions/FactionEdit.vue'
+import FactionCreate from '@/components/expressions/factions/FactionCreate.vue'
+
+export const factionDialogs = () => {
+  const dialog = useDialog()
+
+  const showUpdateFaction = (factionId: number) => {
+    dialog.open(FactionEdit, {
+      props: {
+        header: 'Update Faction',
+        style: {
+          width: '500px',
+        },
+        breakpoints: {
+          '960px': '75vw',
+          '640px': '90vw',
+        },
+        modal: true,
+      },
+      data: {
+        factionId: factionId,
+      },
+    })
+  }
+
+  const showCreateFaction = () => {
+    dialog.open(FactionCreate, {
+      props: {
+        header: 'Create Faction',
+        style: {
+          width: '500px',
+        },
+        breakpoints: {
+          '960px': '75vw',
+          '640px': '90vw',
+        },
+        modal: true,
+      },
+      data: {
+      },
+    })
+  }
+  return {
+    showUpdateFaction,
+    showCreateFaction,
+  }
+}

--- a/client/src/components/characters/wizard/factions/services/factionService.ts
+++ b/client/src/components/characters/wizard/factions/services/factionService.ts
@@ -1,0 +1,8 @@
+import axios from 'axios'
+import type { FactionLevelsResponse } from '@/components/characters/wizard/factions/types.ts'
+
+export const characterFactionService = {
+  getCharacterFaction: (id: number): Promise<FactionLevelsResponse> => axios.get<FactionLevelsResponse>(`/characters/${id}/factions`)
+    .then(async (response) => { return response.data }),
+  pickFaction: (characterId: number, factionId: number) => axios.post(`/characters/${characterId}/factions/${factionId}`),
+}

--- a/client/src/components/characters/wizard/factions/stores/factionStore.ts
+++ b/client/src/components/characters/wizard/factions/stores/factionStore.ts
@@ -1,0 +1,29 @@
+import { defineQueryOptions, useMutation, useQueryCache } from '@pinia/colada'
+import { characterFactionService } from '@/components/characters/wizard/factions/services/factionService.ts'
+import { handleValidationErrors } from '@/utilities/piniaColadaUtilities.ts'
+import type { PickFactionInfo } from '@/components/characters/wizard/factions/types.ts'
+
+export const CHARACTER_FACTION_QUERY_KEYS = {
+  root: ['character_faction'] as const,
+  getCharacterFactions: (characterId: number) => ['character_faction', 'list', characterId] as const,
+}
+
+export const pickedFactionQuery = defineQueryOptions((characterId: number) => ({
+  key: CHARACTER_FACTION_QUERY_KEYS.getCharacterFactions(characterId),
+  query: () => characterFactionService.getCharacterFaction(characterId),
+  enabled: () => characterId != 0,
+}))
+
+export const pickFaction = (onValidationError?: (errors: Record<string, any>) => void | undefined) => {
+  const queryCache = useQueryCache()
+
+  return useMutation({
+    mutation: ({ data }: { data: PickFactionInfo }) => characterFactionService.pickFaction(data.characterId, data.factionId),
+    async onSuccess() {
+      await queryCache.invalidateQueries({ key: CHARACTER_FACTION_QUERY_KEYS.root })
+    },
+    onError(error: any) {
+      handleValidationErrors(error, onValidationError)
+    },
+  })
+}

--- a/client/src/components/characters/wizard/factions/types.ts
+++ b/client/src/components/characters/wizard/factions/types.ts
@@ -1,0 +1,59 @@
+import type { ListItem } from '@/types/ListItem.ts'
+import type { Power } from '@/components/expressions/powers/types.ts'
+
+export interface FactionResponse {
+  factions: Array<Faction>
+}
+
+export interface Faction {
+  id: number
+  name: string
+  background: string
+  factionLevels?: FactionLevel[]
+}
+
+export interface FactionLevel {
+  id: number
+  rankName: string
+  knowledgeId?: number | string | null
+  knowledge?: string | null
+  knowledgeLevel?: string | null
+  specialization?: string | null
+  knowledgeLevelId?: number | string | null
+  power?: Power | null
+}
+
+export interface EditSingleFactionInfo {
+  name: string
+  background: string
+}
+
+export interface CreateSingleFactionInfo {
+  name: string
+  background: string
+  knowledge: ListItem
+  specialization: string
+}
+
+export interface PickFactionInfo {
+  characterId: number
+  factionId: number
+}
+
+export interface FactionLevelsResponse {
+  factionLevels: FactionLevel[]
+  factionId: number | null
+}
+
+export interface FactionLevel {
+  factionLevelId: number
+  approver: string | null
+  approvalReason: string | null
+  requestedPromotion: boolean
+  requestedPromotionReason: string | null
+  approvalDate: string | null // ISO 8601 date-time
+  hasKnowledge: boolean
+  hasKnowledgeLevel: boolean
+  hasSpecialization: boolean | null
+  characterNotes: string | null
+}

--- a/client/src/components/characters/wizard/factions/validators/factionCreateValidator.ts
+++ b/client/src/components/characters/wizard/factions/validators/factionCreateValidator.ts
@@ -1,0 +1,30 @@
+import { object, string } from 'yup'
+import { type GenericForm, useGenericForm } from '@/utilities/formUtilities'
+import type { CreateSingleFactionInfo } from '@/components/expressions/factions/types.ts'
+import type { ListItem } from '@/types/ListItem.ts'
+
+const validationSchema = object({
+  name: string()
+    .required()
+    .max(250)
+    .label('Name'),
+  background: string()
+    .required()
+    .max(20_000)
+    .label('Background'),
+  knowledge: object<ListItem>()
+    .required()
+    .label('Faction Knowledge'),
+  specialization: string()
+    .required()
+    .label('Faction Specialization')
+    .max(250),
+})
+
+export function getValidationInstance(): GenericForm<CreateSingleFactionInfo> {
+  const form = useGenericForm(validationSchema)
+
+  return {
+    ...form,
+  }
+}

--- a/client/src/components/characters/wizard/factions/validators/factionValidator.ts
+++ b/client/src/components/characters/wizard/factions/validators/factionValidator.ts
@@ -1,0 +1,31 @@
+import { object, string } from 'yup'
+import { type GenericForm, useGenericForm } from '@/utilities/formUtilities'
+import type { EditSingleFactionInfo } from '@/components/expressions/factions/types.ts'
+
+const validationSchema = object({
+  name: string()
+    .required()
+    .max(250)
+    .label('Name'),
+  background: string()
+    .required()
+    .max(20_000)
+    .label('Background'),
+}).transform(values => ({
+  name: values.name,
+  background: values.background,
+} as EditSingleFactionInfo))
+
+export function getValidationInstance(): GenericForm<EditSingleFactionInfo> {
+  const form = useGenericForm(validationSchema)
+
+  const setValues = (data: EditSingleFactionInfo) => {
+    form.fields.name.field.value = data.name
+    form.fields.background.field.value = data.background
+  }
+
+  return {
+    ...form,
+    setValues,
+  }
+}

--- a/client/src/components/expressions/factions/stores/factionStore.ts
+++ b/client/src/components/expressions/factions/stores/factionStore.ts
@@ -13,6 +13,7 @@ export const FACTION_QUERY_KEYS = {
 export const factionListQuery = defineQueryOptions((expressionId: number) => ({
   key: FACTION_QUERY_KEYS.getFactionList(expressionId),
   query: () => factionService.getFactions(expressionId),
+  enabled: () => expressionId != 0,
 }))
 
 export const useDeleteFaction = () => {

--- a/client/src/components/expressions/powers/PowerCard.vue
+++ b/client/src/components/expressions/powers/PowerCard.vue
@@ -13,7 +13,7 @@ import { powersStore } from '@/components/expressions/powers/stores/powersStore.
 
 const props = defineProps({
   targetType: {
-    type: Object as PropType<TargetPowerType>,
+    type: Number as PropType<TargetPowerType>,
     required: true,
   },
   power: {


### PR DESCRIPTION
 - One can now see the faction list and join a faction
 - Once joined, it will show requirements and show a request rank approval button if they are met
 - Delete and Request doesn't have functionality tied to them yet
 - Updated backend to pass through Faction Id
 - Navigation History is now preserved in Character Wizard - refreshing page will land on the same section you were on & history navigation will go between pages
 - Switched Imports to be dynamically loaded in with Wizard - saves about 2mb on load