### PR TITLE
Knowledges need to be Restricted Upon Faction Request or Approval

### DIFF
--- a/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/Delete/DeleteCharacterKnowledgeEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/Delete/DeleteCharacterKnowledgeEndpoint.cs
@@ -15,7 +15,11 @@ public static class DeleteCharacterKnowledgeEndpoint
     )
     {
         var results = await useCase.ExecuteAsync(
-            new DeleteKnowledgeFromCharacterModel() { CharacterId = characterId, MappingId = mappingId }
+            new DeleteKnowledgeFromCharacterModel()
+            {
+                CharacterId = characterId,
+                MappingId = mappingId,
+            }
         );
 
         if (results.HasValidationError(out var validationProblem))

--- a/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/Delete/DeleteCharacterKnowledgeEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/Delete/DeleteCharacterKnowledgeEndpoint.cs
@@ -15,7 +15,7 @@ public static class DeleteCharacterKnowledgeEndpoint
     )
     {
         var results = await useCase.ExecuteAsync(
-            new DeleteKnowledgeFromCharacterModel() { MappingId = mappingId }
+            new DeleteKnowledgeFromCharacterModel() { CharacterId = characterId, MappingId = mappingId }
         );
 
         if (results.HasValidationError(out var validationProblem))

--- a/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/Edit/EditCharacterKnowledgeEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/Edit/EditCharacterKnowledgeEndpoint.cs
@@ -20,6 +20,7 @@ public static class EditCharacterKnowledgeEndpoint
         var results = await editKnowledgeUseCase.ExecuteAsync(
             new UpdateKnowledgeForCharacterModel()
             {
+                CharacterId = characterId,
                 MappingId = mappingId,
                 KnowledgeLevelId = request.KnowledgeLevelId,
                 Notes = request.Notes,

--- a/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/CharacterKnowledgeResponse.cs
+++ b/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/CharacterKnowledgeResponse.cs
@@ -1,5 +1,3 @@
-using ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.GetReadOnly;
-
 namespace ExpressedRealms.Knowledges.API.CharacterKnowledges.GetAll;
 
 public class CharacterKnowledgeResponse
@@ -13,4 +11,5 @@ public class CharacterKnowledgeResponse
     public string? Notes { get; set; }
     public int LevelId { get; set; }
     public int SpecializationCount { get; set; }
+    public int? MinimumKnowledgeId { get; set; }
 }

--- a/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/GetCharacterKnowledgesEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/GetCharacterKnowledgesEndpoint.cs
@@ -28,7 +28,7 @@ public static class GetCharacterKnowledgesEndpoint
                             Name = x.Knowledge.Name,
                             Description = x.Knowledge.Description,
                             Type = x.Knowledge.Type,
-                            BlockFactionChanges = x.Knowledge.BlockFactionChanges
+                            BlockFactionChanges = x.Knowledge.BlockFactionChanges,
                         },
                         StoneModifier = x.StoneModifier,
                         LevelName = x.LevelName,
@@ -44,7 +44,7 @@ public static class GetCharacterKnowledgesEndpoint
                                 Description = y.Description,
                                 Id = y.Id,
                                 Notes = y.Notes,
-                                BlockFactionChanges = y.BlockFactionChanges
+                                BlockFactionChanges = y.BlockFactionChanges,
                             })
                             .ToList(),
                     })

--- a/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/GetCharacterKnowledgesEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/GetCharacterKnowledgesEndpoint.cs
@@ -28,6 +28,7 @@ public static class GetCharacterKnowledgesEndpoint
                             Name = x.Knowledge.Name,
                             Description = x.Knowledge.Description,
                             Type = x.Knowledge.Type,
+                            BlockFactionChanges = x.Knowledge.BlockFactionChanges
                         },
                         StoneModifier = x.StoneModifier,
                         LevelName = x.LevelName,
@@ -35,6 +36,7 @@ public static class GetCharacterKnowledgesEndpoint
                         LevelId = x.LevelId,
                         Notes = x.Notes,
                         SpecializationCount = x.SpecializationCount,
+                        MinimumKnowledgeId = x.MinimumKnowledgeId,
                         Specializations = x
                             .Specializations.Select(y => new SpecializationModel()
                             {
@@ -42,6 +44,7 @@ public static class GetCharacterKnowledgesEndpoint
                                 Description = y.Description,
                                 Id = y.Id,
                                 Notes = y.Notes,
+                                BlockFactionChanges = y.BlockFactionChanges
                             })
                             .ToList(),
                     })

--- a/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/KnowledgeModel.cs
+++ b/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/KnowledgeModel.cs
@@ -6,4 +6,5 @@ public class KnowledgeModel
     public required string Description { get; set; }
     public required string Type { get; set; }
     public int Id { get; set; }
+    public bool BlockFactionChanges { get; set; }
 }

--- a/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/SpecializationModel.cs
+++ b/api/ExpressedRealms.Knowledges.API/CharacterKnowledges/GetAll/SpecializationModel.cs
@@ -6,4 +6,5 @@ public class SpecializationModel
     public required string Name { get; set; }
     public required string Description { get; set; }
     public string? Notes { get; set; }
+    public bool BlockFactionChanges { get; set; }
 }

--- a/api/ExpressedRealms.Knowledges.API/KnowledgeSpecializations/Delete/DeleteCharacterSpecializationEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/KnowledgeSpecializations/Delete/DeleteCharacterSpecializationEndpoint.cs
@@ -16,7 +16,7 @@ public static class DeleteCharacterSpecializationEndpoint
     )
     {
         var results = await useCase.ExecuteAsync(
-            new DeleteSpecializationModel() { Id = specializationId }
+            new DeleteSpecializationModel() { Id = specializationId, CharacterId = characterId}
         );
 
         if (results.HasValidationError(out var validationProblem))

--- a/api/ExpressedRealms.Knowledges.API/KnowledgeSpecializations/Delete/DeleteCharacterSpecializationEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/KnowledgeSpecializations/Delete/DeleteCharacterSpecializationEndpoint.cs
@@ -16,7 +16,7 @@ public static class DeleteCharacterSpecializationEndpoint
     )
     {
         var results = await useCase.ExecuteAsync(
-            new DeleteSpecializationModel() { Id = specializationId, CharacterId = characterId}
+            new DeleteSpecializationModel() { Id = specializationId, CharacterId = characterId }
         );
 
         if (results.HasValidationError(out var validationProblem))

--- a/api/ExpressedRealms.Knowledges.API/KnowledgeSpecializations/Edit/EditCharacterSpecializationEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/KnowledgeSpecializations/Edit/EditCharacterSpecializationEndpoint.cs
@@ -1,5 +1,3 @@
-using ExpressedRealms.Knowledges.API.CharacterKnowledges.Edit;
-using ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.Edit;
 using ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.EditSpecialization;
 using ExpressedRealms.Server.Shared;
 using Microsoft.AspNetCore.Http;
@@ -25,6 +23,7 @@ public static class EditCharacterSpecializationEndpoint
                 Description = request.Description,
                 Name = request.Name,
                 Notes = request.Notes,
+                CharacterId = characterId
             }
         );
 

--- a/api/ExpressedRealms.Knowledges.API/KnowledgeSpecializations/Edit/EditCharacterSpecializationEndpoint.cs
+++ b/api/ExpressedRealms.Knowledges.API/KnowledgeSpecializations/Edit/EditCharacterSpecializationEndpoint.cs
@@ -23,7 +23,7 @@ public static class EditCharacterSpecializationEndpoint
                 Description = request.Description,
                 Name = request.Name,
                 Notes = request.Notes,
-                CharacterId = characterId
+                CharacterId = characterId,
             }
         );
 

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/DeleteKnowledgeFromCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/DeleteKnowledgeFromCharacterUseCaseTests.cs
@@ -96,7 +96,8 @@ public class DeleteKnowledgeFromCharacterUseCaseTests
     [Fact]
     public async Task ValidationFor_CharacterId_WillFail_WhenCharacterDoesNotExist()
     {
-        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(false);
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId))
+            .Returns(false);
 
         var result = await _useCase.ExecuteAsync(_model);
 
@@ -128,14 +129,7 @@ public class DeleteKnowledgeFromCharacterUseCaseTests
     public async Task UseCase_WillFail_WhenFactionLevelRequires_TheKnowledge()
     {
         A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
-            .Returns(
-                [
-                    new CharacterFactionDto()
-                    {
-                        KnowledgeId = 4,
-                    },
-                ]
-            );
+            .Returns([new CharacterFactionDto() { KnowledgeId = 4 }]);
 
         var result = await _useCase.ExecuteAsync(_model);
 
@@ -149,14 +143,7 @@ public class DeleteKnowledgeFromCharacterUseCaseTests
     public async Task UseCase_WillNotUpdateDeleteFields_WhenFactionLevelRequires_TheKnowledge()
     {
         A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
-            .Returns(
-                [
-                    new CharacterFactionDto()
-                    {
-                        KnowledgeId = 4,
-                    },
-                ]
-            );
+            .Returns([new CharacterFactionDto() { KnowledgeId = 4 }]);
 
         await _useCase.ExecuteAsync(_model);
 

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/DeleteKnowledgeFromCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/DeleteKnowledgeFromCharacterUseCaseTests.cs
@@ -1,4 +1,7 @@
+using ExpressedRealms.Characters.Repository;
 using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeMappings;
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
+using ExpressedRealms.Expressions.Repository.CharacterFactions.Dtos;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.Delete;
 using ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.Edit;
@@ -12,31 +15,42 @@ public class DeleteKnowledgeFromCharacterUseCaseTests
 {
     private readonly DeleteKnowledgeFromCharacterUseCase _useCase;
     private readonly ICharacterKnowledgeRepository _mappingRepository;
+    private readonly ICharacterRepository _characterRepository;
+    private readonly ICharacterFactionRepository _characterFactionRepository;
     private readonly DeleteKnowledgeFromCharacterModel _model;
 
     public DeleteKnowledgeFromCharacterUseCaseTests()
     {
-        _model = new DeleteKnowledgeFromCharacterModel() { MappingId = 1 };
+        _model = new DeleteKnowledgeFromCharacterModel() { MappingId = 1, CharacterId = 2 };
 
         var dbModel = new CharacterKnowledgeMapping()
         {
             KnowledgeLevelId = 3,
-            CharacterId = 2,
+            CharacterId = _model.CharacterId,
             KnowledgeId = 4,
             Notes = "123",
         };
 
         _mappingRepository = A.Fake<ICharacterKnowledgeRepository>();
+        _characterRepository = A.Fake<ICharacterRepository>();
+        _characterFactionRepository = A.Fake<ICharacterFactionRepository>();
 
         A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(_model.MappingId))
             .Returns(dbModel);
 
         A.CallTo(() => _mappingRepository.MappingAlreadyExists(_model.MappingId)).Returns(true);
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(true);
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns([]);
 
-        var validator = new DeleteKnowledgeFromCharacterModelValidator(_mappingRepository);
+        var validator = new DeleteKnowledgeFromCharacterModelValidator(
+            _mappingRepository,
+            _characterRepository
+        );
 
         _useCase = new DeleteKnowledgeFromCharacterUseCase(
             _mappingRepository,
+            _characterFactionRepository,
             validator,
             CancellationToken.None
         );
@@ -67,12 +81,89 @@ public class DeleteKnowledgeFromCharacterUseCaseTests
     }
 
     [Fact]
+    public async Task ValidationFor_CharacterId_WillFail_WhenCharacterId_IsEmpty()
+    {
+        _model.CharacterId = 0;
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        result.MustHaveValidationError(
+            nameof(DeleteKnowledgeFromCharacterModel.CharacterId),
+            "Character Id is required."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_CharacterId_WillFail_WhenCharacterDoesNotExist()
+    {
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(false);
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        result.MustHaveValidationError(
+            nameof(DeleteKnowledgeFromCharacterModel.CharacterId),
+            "This Character was not found."
+        );
+    }
+
+    [Fact]
     public async Task UseCase_GetsTheKnowledgeMapping()
     {
         await _useCase.ExecuteAsync(_model);
 
         A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(_model.MappingId))
             .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillGrab_TheLatestPlayerFactionLevels()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillFail_WhenFactionLevelRequires_TheKnowledge()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = 4,
+                    },
+                ]
+            );
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        result.MustHaveValidationError(
+            nameof(DeleteKnowledgeFromCharacterModel.MappingId),
+            "Your faction level prevents you from removing this knowledge"
+        );
+    }
+
+    [Fact]
+    public async Task UseCase_WillNotUpdateDeleteFields_WhenFactionLevelRequires_TheKnowledge()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = 4,
+                    },
+                ]
+            );
+
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() =>
+                _mappingRepository.UpdateCharacterKnowledgeMapping(A<CharacterKnowledgeMapping>._)
+            )
+            .MustNotHaveHappened();
     }
 
     [Fact]

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/GetKnowledgeForCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/GetKnowledgeForCharacterUseCaseTests.cs
@@ -1,4 +1,7 @@
 using ExpressedRealms.Characters.Repository;
+using ExpressedRealms.DB.Models.Knowledges.KnowledgeEducationLevels;
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
+using ExpressedRealms.Expressions.Repository.CharacterFactions.Dtos;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings.Projections;
 using ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.GetReadOnly;
@@ -13,6 +16,7 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
     private readonly GetKnowledgesForCharacterUseCase _useCase;
     private readonly ICharacterKnowledgeRepository _mappingRepository;
     private readonly ICharacterRepository _characterRepository;
+    private readonly ICharacterFactionRepository _characterFactionRepository;
     private readonly GetKnowledgesForCharacterModel _model;
     private readonly List<CharacterKnowledgeProjection> _dbModel;
 
@@ -77,16 +81,20 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
 
         _mappingRepository = A.Fake<ICharacterKnowledgeRepository>();
         _characterRepository = A.Fake<ICharacterRepository>();
+        _characterFactionRepository = A.Fake<ICharacterFactionRepository>();
 
         A.CallTo(() => _mappingRepository.GetKnowledgesForCharacter(_model.CharacterId))
             .Returns(_dbModel);
 
         A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(true);
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns([]);
 
         var validator = new GetKnowledgesForCharacterModelValidator(_characterRepository);
 
         _useCase = new GetKnowledgesForCharacterUseCase(
             _mappingRepository,
+            _characterFactionRepository,
             validator,
             CancellationToken.None
         );
@@ -127,6 +135,15 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
     }
 
     [Fact]
+    public async Task UseCase_GetsLatestPlayerFactionLevels()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
     public async Task UseCase_ReturnsKnowledgesForCharacter()
     {
         var results = await _useCase.ExecuteAsync(_model);
@@ -142,6 +159,7 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
                     Name = x.Knowledge.Name,
                     Description = x.Knowledge.Description,
                     Type = x.Knowledge.Type,
+                    BlockFactionChanges = true,
                 },
                 StoneModifier = x.StoneModifier,
                 LevelName = x.LevelName,
@@ -149,6 +167,7 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
                 Notes = x.Notes,
                 SpecializationCount = x.SpecializationCount,
                 LevelId = x.LevelId,
+                MinimumKnowledgeId = null,
                 Specializations = x
                     .Specializations.Select(y => new SpecializationReturnModel()
                     {
@@ -156,11 +175,100 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
                         Description = y.Description,
                         Id = y.Id,
                         Notes = y.Notes,
+                        BlockFactionChanges = false,
                     })
                     .ToList(),
             })
             .ToList();
 
         Assert.Equivalent(knowledges, results.Value);
+    }
+
+    [Fact]
+    public async Task UseCase_WillMarkKnowledge_AsBlockedFromFactionChanges_WhenFactionDoesNotRequireKnowledge()
+    {
+        var results = await _useCase.ExecuteAsync(_model);
+
+        Assert.True(results.Value.Single(x => x.Knowledge.Id == 29).Knowledge.BlockFactionChanges);
+        Assert.True(results.Value.Single(x => x.Knowledge.Id == 30).Knowledge.BlockFactionChanges);
+    }
+
+    [Fact]
+    public async Task UseCase_WillMarkKnowledge_AsNotBlockedFromFactionChanges_WhenFactionRequiresKnowledge()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = 29,
+                        KnowledgeLevel = new KnowledgeEducationLevel()
+                        {
+                            Id = 3,
+                        },
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        Assert.False(results.Value.Single(x => x.Knowledge.Id == 29).Knowledge.BlockFactionChanges);
+        Assert.True(results.Value.Single(x => x.Knowledge.Id == 30).Knowledge.BlockFactionChanges);
+    }
+
+    [Fact]
+    public async Task UseCase_WillSetMinimumKnowledgeId_WhenFactionRequiresKnowledge()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = 29,
+                        KnowledgeLevel = new KnowledgeEducationLevel()
+                        {
+                            Id = 3,
+                        },
+                    },
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = 29,
+                        KnowledgeLevel = new KnowledgeEducationLevel()
+                        {
+                            Id = 5,
+                        },
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        Assert.Equal(5, results.Value.Single(x => x.Knowledge.Id == 29).MinimumKnowledgeId);
+        Assert.Null(results.Value.Single(x => x.Knowledge.Id == 30).MinimumKnowledgeId);
+    }
+
+    [Fact]
+    public async Task UseCase_WillMarkSpecialization_AsBlockedFromFactionChanges_WhenFactionRequiresSpecialization()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeSpecialization = "Specialization",
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        var knowledge = results.Value.Single(x => x.Knowledge.Id == 29);
+
+        Assert.True(
+            knowledge.Specializations.Single(x => x.Name == "Specialization").BlockFactionChanges
+        );
+        Assert.False(
+            knowledge.Specializations.Single(x => x.Name == "Specialization 2").BlockFactionChanges
+        );
     }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/GetKnowledgeForCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/GetKnowledgeForCharacterUseCaseTests.cs
@@ -255,6 +255,7 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = 29,
                         KnowledgeSpecialization = "Specialization",
                     },
                 ]
@@ -265,6 +266,32 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
         var knowledge = results.Value.Single(x => x.Knowledge.Id == 29);
 
         Assert.True(
+            knowledge.Specializations.Single(x => x.Name == "Specialization").BlockFactionChanges
+        );
+        Assert.False(
+            knowledge.Specializations.Single(x => x.Name == "Specialization 2").BlockFactionChanges
+        );
+    }
+
+    [Fact]
+    public async Task UseCase_WillNotMarkSpecialization_AsBlockedFromFactionChanges_WhenFactionRequiresSameSpecializationName_ForDifferentKnowledge()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = 30,
+                        KnowledgeSpecialization = "Specialization",
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        var knowledge = results.Value.Single(x => x.Knowledge.Id == 29);
+
+        Assert.False(
             knowledge.Specializations.Single(x => x.Name == "Specialization").BlockFactionChanges
         );
         Assert.False(

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/GetKnowledgeForCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/GetKnowledgeForCharacterUseCaseTests.cs
@@ -202,10 +202,7 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
                     new CharacterFactionDto()
                     {
                         KnowledgeId = 29,
-                        KnowledgeLevel = new KnowledgeEducationLevel()
-                        {
-                            Id = 3,
-                        },
+                        KnowledgeLevel = new KnowledgeEducationLevel() { Id = 3 },
                     },
                 ]
             );
@@ -225,18 +222,12 @@ public class GetReadOnlyKnowledgesForCharacterUseCaseTests
                     new CharacterFactionDto()
                     {
                         KnowledgeId = 29,
-                        KnowledgeLevel = new KnowledgeEducationLevel()
-                        {
-                            Id = 3,
-                        },
+                        KnowledgeLevel = new KnowledgeEducationLevel() { Id = 3 },
                     },
                     new CharacterFactionDto()
                     {
                         KnowledgeId = 29,
-                        KnowledgeLevel = new KnowledgeEducationLevel()
-                        {
-                            Id = 5,
-                        },
+                        KnowledgeLevel = new KnowledgeEducationLevel() { Id = 5 },
                     },
                 ]
             );

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/UpdateKnowledgeForCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/UpdateKnowledgeForCharacterUseCaseTests.cs
@@ -1,9 +1,12 @@
+using ExpressedRealms.Characters.Repository;
 using ExpressedRealms.Characters.Repository.Xp;
 using ExpressedRealms.Characters.Repository.Xp.Dtos;
 using ExpressedRealms.DB.Models.Characters.XpTables;
 using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeMappings;
 using ExpressedRealms.DB.Models.Knowledges.KnowledgeEducationLevels;
 using ExpressedRealms.DB.Models.Knowledges.KnowledgeModels;
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
+using ExpressedRealms.Expressions.Repository.CharacterFactions.Dtos;
 using ExpressedRealms.Knowledges.Repository;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.Repository.Knowledges;
@@ -25,6 +28,8 @@ public class UpdateKnowledgeForCharacterUseCaseTests
     private readonly IKnowledgeLevelRepository _levelRepository;
     private readonly UpdateKnowledgeForCharacterModel _model;
     private readonly IXpRepository _xpRepository;
+    private readonly ICharacterRepository _characterRepository;
+    private readonly ICharacterFactionRepository _characterFactionRepository;
     private readonly CharacterKnowledgeMapping _dbModel;
 
     public UpdateKnowledgeForCharacterUseCaseTests()
@@ -34,12 +39,13 @@ public class UpdateKnowledgeForCharacterUseCaseTests
             MappingId = 1,
             KnowledgeLevelId = 2,
             Notes = "123",
+            CharacterId = 2,
         };
 
         _dbModel = new CharacterKnowledgeMapping()
         {
             KnowledgeLevelId = 3,
-            CharacterId = 2,
+            CharacterId = _model.CharacterId,
             KnowledgeId = 4,
             Notes = "123",
         };
@@ -48,6 +54,8 @@ public class UpdateKnowledgeForCharacterUseCaseTests
         _mappingRepository = A.Fake<ICharacterKnowledgeRepository>();
         _levelRepository = A.Fake<IKnowledgeLevelRepository>();
         _xpRepository = A.Fake<IXpRepository>();
+        _characterRepository = A.Fake<ICharacterRepository>();
+        _characterFactionRepository = A.Fake<ICharacterFactionRepository>();
 
         A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(_model.MappingId))
             .Returns(_dbModel);
@@ -55,6 +63,9 @@ public class UpdateKnowledgeForCharacterUseCaseTests
         A.CallTo(() => _levelRepository.KnowledgeLevelExists(_model.KnowledgeLevelId))
             .Returns(true);
         A.CallTo(() => _mappingRepository.MappingAlreadyExists(_model.MappingId)).Returns(true);
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(true);
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns([]);
         A.CallTo(() =>
                 _xpRepository.GetAvailableXpForSection(
                     _dbModel.CharacterId,
@@ -78,13 +89,15 @@ public class UpdateKnowledgeForCharacterUseCaseTests
         var validator = new UpdateKnowledgeForCharacterModelValidator(
             _knowledgeRepository,
             _mappingRepository,
-            _levelRepository
+            _levelRepository,
+            _characterRepository
         );
 
         _useCase = new UpdateKnowledgeForCharacterUseCase(
             _mappingRepository,
             _levelRepository,
             _knowledgeRepository,
+            _characterFactionRepository,
             _xpRepository,
             validator,
             CancellationToken.None
@@ -112,6 +125,32 @@ public class UpdateKnowledgeForCharacterUseCaseTests
         result.MustHaveValidationError(
             nameof(UpdateKnowledgeForCharacterModel.MappingId),
             "The Knowledge Mapping does not exist."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_CharacterId_WillFail_WhenItsEmpty()
+    {
+        _model.CharacterId = 0;
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        result.MustHaveValidationError(
+            nameof(UpdateKnowledgeForCharacterModel.CharacterId),
+            "Character Id is required."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_CharacterId_WillFail_WhenItDoesNotExist()
+    {
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(false);
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        result.MustHaveValidationError(
+            nameof(UpdateKnowledgeForCharacterModel.CharacterId),
+            "This Character was not found."
         );
     }
 
@@ -178,6 +217,75 @@ public class UpdateKnowledgeForCharacterUseCaseTests
 
         A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(_model.MappingId))
             .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_GetsLatestPlayerFactionLevels_WhenKnowledgeLevelChanges()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_DoesNotGetLatestPlayerFactionLevels_WhenOnlyNotesChange()
+    {
+        _model.KnowledgeLevelId = 3;
+        _dbModel.KnowledgeLevelId = 3;
+
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task UseCase_WillFail_WhenFactionLevelPreventsKnowledgeLevelChange()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeLevel = new KnowledgeEducationLevel()
+                        {
+                            Id = 1,
+                        },
+                    },
+                ]
+            );
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        result.MustHaveValidationError(
+            nameof(UpdateKnowledgeForCharacterModel.KnowledgeLevelId),
+            "Your faction level prevents you from applying this knowledge level change."
+        );
+    }
+
+    [Fact]
+    public async Task UseCase_WillNotUpdate_WhenFactionLevelPreventsKnowledgeLevelChange()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeLevel = new KnowledgeEducationLevel()
+                        {
+                            Id = 1,
+                        },
+                    },
+                ]
+            );
+
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() =>
+                _mappingRepository.UpdateCharacterKnowledgeMapping(A<CharacterKnowledgeMapping>._)
+            )
+            .MustNotHaveHappened();
     }
 
     [Fact]

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/UpdateKnowledgeForCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/UpdateKnowledgeForCharacterUseCaseTests.cs
@@ -248,6 +248,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = _dbModel.KnowledgeId,
                         KnowledgeLevel = new KnowledgeEducationLevel()
                         {
                             Id = 3,
@@ -272,6 +273,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = _dbModel.KnowledgeId,
                         KnowledgeLevel = new KnowledgeEducationLevel()
                         {
                             Id = 3,
@@ -289,6 +291,28 @@ public class UpdateKnowledgeForCharacterUseCaseTests
     }
 
     [Fact]
+    public async Task UseCase_WillAllowKnowledgeLevelChange_WhenFactionLevelIsForDifferentKnowledge()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = _dbModel.KnowledgeId + 1,
+                        KnowledgeLevel = new KnowledgeEducationLevel()
+                        {
+                            Id = 3,
+                        },
+                    },
+                ]
+            );
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
     public async Task UseCase_WillAllowKnowledgeLevelChange_WhenFactionLevelIsEqualToRequestedLevel()
     {
         A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
@@ -296,6 +320,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = _dbModel.KnowledgeId,
                         KnowledgeLevel = new KnowledgeEducationLevel()
                         {
                             Id = _model.KnowledgeLevelId,
@@ -317,6 +342,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = _dbModel.KnowledgeId,
                         KnowledgeLevel = new KnowledgeEducationLevel()
                         {
                             Id = _model.KnowledgeLevelId - 1,
@@ -338,6 +364,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = _dbModel.KnowledgeId,
                         KnowledgeLevel = null,
                     },
                 ]

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/UpdateKnowledgeForCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/UpdateKnowledgeForCharacterUseCaseTests.cs
@@ -250,7 +250,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                     {
                         KnowledgeLevel = new KnowledgeEducationLevel()
                         {
-                            Id = 1,
+                            Id = 3,
                         },
                     },
                 ]
@@ -274,7 +274,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                     {
                         KnowledgeLevel = new KnowledgeEducationLevel()
                         {
-                            Id = 1,
+                            Id = 3,
                         },
                     },
                 ]
@@ -286,6 +286,66 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                 _mappingRepository.UpdateCharacterKnowledgeMapping(A<CharacterKnowledgeMapping>._)
             )
             .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task UseCase_WillAllowKnowledgeLevelChange_WhenFactionLevelIsEqualToRequestedLevel()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeLevel = new KnowledgeEducationLevel()
+                        {
+                            Id = _model.KnowledgeLevelId,
+                        },
+                    },
+                ]
+            );
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task UseCase_WillAllowKnowledgeLevelChange_WhenFactionLevelIsLowerThanRequestedLevel()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeLevel = new KnowledgeEducationLevel()
+                        {
+                            Id = _model.KnowledgeLevelId - 1,
+                        },
+                    },
+                ]
+            );
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task UseCase_WillIgnoreFactionLevels_WithoutKnowledgeLevel()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeLevel = null,
+                    },
+                ]
+            );
+
+        var result = await _useCase.ExecuteAsync(_model);
+
+        Assert.True(result.IsSuccess);
     }
 
     [Fact]

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/UpdateKnowledgeForCharacterUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/CharacterKnowledgeMappingTests/UpdateKnowledgeForCharacterUseCaseTests.cs
@@ -144,7 +144,8 @@ public class UpdateKnowledgeForCharacterUseCaseTests
     [Fact]
     public async Task ValidationFor_CharacterId_WillFail_WhenItDoesNotExist()
     {
-        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(false);
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId))
+            .Returns(false);
 
         var result = await _useCase.ExecuteAsync(_model);
 
@@ -249,10 +250,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                     new CharacterFactionDto()
                     {
                         KnowledgeId = _dbModel.KnowledgeId,
-                        KnowledgeLevel = new KnowledgeEducationLevel()
-                        {
-                            Id = 3,
-                        },
+                        KnowledgeLevel = new KnowledgeEducationLevel() { Id = 3 },
                     },
                 ]
             );
@@ -274,10 +272,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                     new CharacterFactionDto()
                     {
                         KnowledgeId = _dbModel.KnowledgeId,
-                        KnowledgeLevel = new KnowledgeEducationLevel()
-                        {
-                            Id = 3,
-                        },
+                        KnowledgeLevel = new KnowledgeEducationLevel() { Id = 3 },
                     },
                 ]
             );
@@ -299,10 +294,7 @@ public class UpdateKnowledgeForCharacterUseCaseTests
                     new CharacterFactionDto()
                     {
                         KnowledgeId = _dbModel.KnowledgeId + 1,
-                        KnowledgeLevel = new KnowledgeEducationLevel()
-                        {
-                            Id = 3,
-                        },
+                        KnowledgeLevel = new KnowledgeEducationLevel() { Id = 3 },
                     },
                 ]
             );

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/DeleteSpecializationUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/DeleteSpecializationUseCaseTests.cs
@@ -1,8 +1,10 @@
 using ExpressedRealms.Characters.Repository;
+using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeMappings;
 using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeSpecializations;
 using ExpressedRealms.DB.Models.Knowledges.KnowledgeModels;
 using ExpressedRealms.Expressions.Repository.CharacterFactions;
 using ExpressedRealms.Expressions.Repository.CharacterFactions.Dtos;
+using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
 using ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.DeleteSpecialization;
 using ExpressedRealms.Shared.UseCases.Tests.Unit;
@@ -15,6 +17,7 @@ public class DeleteSpecializationUseCaseTests
 {
     private readonly DeleteSpecializationUseCase _useCase;
     private readonly IKnowledgeSpecializationRepository _repository;
+    private readonly ICharacterKnowledgeRepository _mappingRepository;
     private readonly ICharacterRepository _characterRepository;
     private readonly ICharacterFactionRepository _characterFactionRepository;
     private readonly DeleteSpecializationModel _model;
@@ -24,6 +27,7 @@ public class DeleteSpecializationUseCaseTests
         _model = new DeleteSpecializationModel() { Id = 4, CharacterId = 2 };
 
         _repository = A.Fake<IKnowledgeSpecializationRepository>();
+        _mappingRepository = A.Fake<ICharacterKnowledgeRepository>();
         _characterRepository = A.Fake<ICharacterRepository>();
         _characterFactionRepository = A.Fake<ICharacterFactionRepository>();
 
@@ -35,6 +39,14 @@ public class DeleteSpecializationUseCaseTests
                 {
                     Id = _model.Id,
                     Name = "Forgery",
+                    KnowledgeMappingId = 8,
+                }
+            );
+        A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(8))
+            .Returns(
+                new CharacterKnowledgeMapping()
+                {
+                    KnowledgeId = 12,
                 }
             );
         A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
@@ -45,55 +57,13 @@ public class DeleteSpecializationUseCaseTests
         _useCase = new DeleteSpecializationUseCase(
             _repository,
             _characterFactionRepository,
+            _mappingRepository,
             validator,
             CancellationToken.None
         );
     }
 
-    [Fact]
-    public async Task ValidationFor_Id_WillFail_WhenId_IsEmpty()
-    {
-        _model.Id = 0;
-        var results = await _useCase.ExecuteAsync(_model);
-        results.MustHaveValidationError(nameof(DeleteSpecializationModel.Id), "Id is required.");
-    }
-
-    [Fact]
-    public async Task ValidationFor_Id_WillFail_KnowledgeDoesNotExist()
-    {
-        A.CallTo(() => _repository.SpecializationExists(_model.Id)).Returns(false);
-        var results = await _useCase.ExecuteAsync(_model);
-        results.MustHaveValidationError(
-            nameof(DeleteSpecializationModel.Id),
-            "This Specialization was not found."
-        );
-    }
-
-    [Fact]
-    public async Task ValidationFor_CharacterId_WillFail_WhenCharacterId_IsEmpty()
-    {
-        _model.CharacterId = 0;
-
-        var results = await _useCase.ExecuteAsync(_model);
-
-        results.MustHaveValidationError(
-            nameof(DeleteSpecializationModel.CharacterId),
-            "Character Id is required."
-        );
-    }
-
-    [Fact]
-    public async Task ValidationFor_CharacterId_WillFail_WhenCharacterDoesNotExist()
-    {
-        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(false);
-
-        var results = await _useCase.ExecuteAsync(_model);
-
-        results.MustHaveValidationError(
-            nameof(DeleteSpecializationModel.CharacterId),
-            "This Character was not found."
-        );
-    }
+    // ... existing code ...
 
     [Fact]
     public async Task UseCase_WillGrab_TheKnowledge()
@@ -101,6 +71,15 @@ public class DeleteSpecializationUseCaseTests
         await _useCase.ExecuteAsync(_model);
 
         A.CallTo(() => _repository.GetSpecialization(_model.Id)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillGrab_TheKnowledgeMapping()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(8))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -120,6 +99,7 @@ public class DeleteSpecializationUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = 12,
                         KnowledgeSpecialization = "Forgery",
                     },
                 ]
@@ -141,6 +121,7 @@ public class DeleteSpecializationUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = 12,
                         KnowledgeSpecialization = "Forgery",
                     },
                 ]
@@ -152,6 +133,25 @@ public class DeleteSpecializationUseCaseTests
                 _repository.UpdateSpecialization(A<CharacterKnowledgeSpecialization>._)
             )
             .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task UseCase_WillAllowSoftDelete_WhenFactionLevelRequires_SameSpecializationName_ForDifferentKnowledge()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = 13,
+                        KnowledgeSpecialization = "Forgery",
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        Assert.True(results.IsSuccess);
     }
 
     [Fact]

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/DeleteSpecializationUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/DeleteSpecializationUseCaseTests.cs
@@ -1,5 +1,8 @@
+using ExpressedRealms.Characters.Repository;
 using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeSpecializations;
 using ExpressedRealms.DB.Models.Knowledges.KnowledgeModels;
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
+using ExpressedRealms.Expressions.Repository.CharacterFactions.Dtos;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
 using ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.DeleteSpecialization;
 using ExpressedRealms.Shared.UseCases.Tests.Unit;
@@ -12,21 +15,39 @@ public class DeleteSpecializationUseCaseTests
 {
     private readonly DeleteSpecializationUseCase _useCase;
     private readonly IKnowledgeSpecializationRepository _repository;
+    private readonly ICharacterRepository _characterRepository;
+    private readonly ICharacterFactionRepository _characterFactionRepository;
     private readonly DeleteSpecializationModel _model;
 
     public DeleteSpecializationUseCaseTests()
     {
-        _model = new DeleteSpecializationModel() { Id = 4 };
+        _model = new DeleteSpecializationModel() { Id = 4, CharacterId = 2 };
 
         _repository = A.Fake<IKnowledgeSpecializationRepository>();
+        _characterRepository = A.Fake<ICharacterRepository>();
+        _characterFactionRepository = A.Fake<ICharacterFactionRepository>();
 
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(true);
         A.CallTo(() => _repository.SpecializationExists(_model.Id)).Returns(true);
         A.CallTo(() => _repository.GetSpecialization(_model.Id))
-            .Returns(new CharacterKnowledgeSpecialization() { Id = _model.Id });
+            .Returns(
+                new CharacterKnowledgeSpecialization()
+                {
+                    Id = _model.Id,
+                    Name = "Forgery",
+                }
+            );
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns([]);
 
-        var validator = new DeleteSpecializationModelValidator(_repository);
+        var validator = new DeleteSpecializationModelValidator(_repository, _characterRepository);
 
-        _useCase = new DeleteSpecializationUseCase(_repository, validator, CancellationToken.None);
+        _useCase = new DeleteSpecializationUseCase(
+            _repository,
+            _characterFactionRepository,
+            validator,
+            CancellationToken.None
+        );
     }
 
     [Fact]
@@ -49,11 +70,88 @@ public class DeleteSpecializationUseCaseTests
     }
 
     [Fact]
+    public async Task ValidationFor_CharacterId_WillFail_WhenCharacterId_IsEmpty()
+    {
+        _model.CharacterId = 0;
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        results.MustHaveValidationError(
+            nameof(DeleteSpecializationModel.CharacterId),
+            "Character Id is required."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_CharacterId_WillFail_WhenCharacterDoesNotExist()
+    {
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(false);
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        results.MustHaveValidationError(
+            nameof(DeleteSpecializationModel.CharacterId),
+            "This Character was not found."
+        );
+    }
+
+    [Fact]
     public async Task UseCase_WillGrab_TheKnowledge()
     {
         await _useCase.ExecuteAsync(_model);
 
         A.CallTo(() => _repository.GetSpecialization(_model.Id)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillGrab_TheLatestPlayerFactionLevels()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillFail_WhenFactionLevelRequires_TheKnowledgeSpecialization()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeSpecialization = "Forgery",
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        results.MustHaveValidationError(
+            nameof(DeleteSpecializationModel.Id),
+            "Your faction level prevents you from removing this knowledge specialization"
+        );
+    }
+
+    [Fact]
+    public async Task UseCase_WillNotSoftDelete_WhenFactionLevelRequires_TheKnowledgeSpecialization()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeSpecialization = "Forgery",
+                    },
+                ]
+            );
+
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() =>
+                _repository.UpdateSpecialization(A<CharacterKnowledgeSpecialization>._)
+            )
+            .MustNotHaveHappened();
     }
 
     [Fact]

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/DeleteSpecializationUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/DeleteSpecializationUseCaseTests.cs
@@ -43,12 +43,7 @@ public class DeleteSpecializationUseCaseTests
                 }
             );
         A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(8))
-            .Returns(
-                new CharacterKnowledgeMapping()
-                {
-                    KnowledgeId = 12,
-                }
-            );
+            .Returns(new CharacterKnowledgeMapping() { KnowledgeId = 12 });
         A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
             .Returns([]);
 
@@ -129,9 +124,7 @@ public class DeleteSpecializationUseCaseTests
 
         await _useCase.ExecuteAsync(_model);
 
-        A.CallTo(() =>
-                _repository.UpdateSpecialization(A<CharacterKnowledgeSpecialization>._)
-            )
+        A.CallTo(() => _repository.UpdateSpecialization(A<CharacterKnowledgeSpecialization>._))
             .MustNotHaveHappened();
     }
 

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/EditSpecializationUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/EditSpecializationUseCaseTests.cs
@@ -48,6 +48,8 @@ public class EditSpecializationUseCaseTests
 
         A.CallTo(() => _specializationRepository.GetSpecialization(_model.Id))
             .Returns(_specializationDbModel);
+        A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(_specializationDbModel.KnowledgeMappingId))
+            .Returns(_mappingDbModel);
         A.CallTo(() => _specializationRepository.SpecializationExists(_model.Id)).Returns(true);
         A.CallTo(() =>
                 _mappingRepository.HasExistingSpecializationForMappingEdit(_model.Id, _model.Name)
@@ -76,6 +78,7 @@ public class EditSpecializationUseCaseTests
         _useCase = new EditSpecializationUseCase(
             _specializationRepository,
             _characterFactionRepository,
+            _mappingRepository,
             validator,
             CancellationToken.None
         );
@@ -219,6 +222,15 @@ public class EditSpecializationUseCaseTests
     }
 
     [Fact]
+    public async Task UseCase_CorrectlyGrabs_TheKnowledgeMapping()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(_specializationDbModel.KnowledgeMappingId))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
     public async Task UseCase_WillGrab_TheLatestPlayerFactionLevels()
     {
         await _useCase.ExecuteAsync(_model);
@@ -235,6 +247,7 @@ public class EditSpecializationUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = _mappingDbModel.KnowledgeId,
                         KnowledgeSpecialization = "Old Specialization Name",
                     },
                 ]
@@ -256,6 +269,7 @@ public class EditSpecializationUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = _mappingDbModel.KnowledgeId,
                         KnowledgeSpecialization = "Old Specialization Name",
                     },
                 ]
@@ -272,6 +286,25 @@ public class EditSpecializationUseCaseTests
     }
 
     [Fact]
+    public async Task UseCase_WillAllowEdit_WhenFactionLevelRequires_TheExistingKnowledgeSpecialization_AndNameChanges_ForDifferentKnowledge()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeId = _mappingDbModel.KnowledgeId + 1,
+                        KnowledgeSpecialization = "Old Specialization Name",
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        Assert.True(results.IsSuccess);
+    }
+
+    [Fact]
     public async Task UseCase_WillAllowEdit_WhenFactionLevelRequires_TheExistingKnowledgeSpecialization_AndNameDoesNotChange()
     {
         _model.Name = "Old Specialization Name";
@@ -280,6 +313,7 @@ public class EditSpecializationUseCaseTests
                 [
                     new CharacterFactionDto()
                     {
+                        KnowledgeId = _mappingDbModel.KnowledgeId,
                         KnowledgeSpecialization = "Old Specialization Name",
                     },
                 ]

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/EditSpecializationUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/EditSpecializationUseCaseTests.cs
@@ -48,7 +48,11 @@ public class EditSpecializationUseCaseTests
 
         A.CallTo(() => _specializationRepository.GetSpecialization(_model.Id))
             .Returns(_specializationDbModel);
-        A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(_specializationDbModel.KnowledgeMappingId))
+        A.CallTo(() =>
+                _mappingRepository.GetCharacterKnowledgeMappingForEditing(
+                    _specializationDbModel.KnowledgeMappingId
+                )
+            )
             .Returns(_mappingDbModel);
         A.CallTo(() => _specializationRepository.SpecializationExists(_model.Id)).Returns(true);
         A.CallTo(() =>
@@ -203,7 +207,8 @@ public class EditSpecializationUseCaseTests
     [Fact]
     public async Task ValidationFor_CharacterId_WillFail_WhenCharacterDoesNotExist()
     {
-        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(false);
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId))
+            .Returns(false);
 
         var results = await _useCase.ExecuteAsync(_model);
 
@@ -226,7 +231,11 @@ public class EditSpecializationUseCaseTests
     {
         await _useCase.ExecuteAsync(_model);
 
-        A.CallTo(() => _mappingRepository.GetCharacterKnowledgeMappingForEditing(_specializationDbModel.KnowledgeMappingId))
+        A.CallTo(() =>
+                _mappingRepository.GetCharacterKnowledgeMappingForEditing(
+                    _specializationDbModel.KnowledgeMappingId
+                )
+            )
             .MustHaveHappenedOnceExactly();
     }
 

--- a/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/EditSpecializationUseCaseTests.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases.Tests.Unit/KnowledgeSpecializationTests/EditSpecializationUseCaseTests.cs
@@ -1,5 +1,8 @@
+using ExpressedRealms.Characters.Repository;
 using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeMappings;
 using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeSpecializations;
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
+using ExpressedRealms.Expressions.Repository.CharacterFactions.Dtos;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
 using ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.EditSpecialization;
@@ -14,6 +17,8 @@ public class EditSpecializationUseCaseTests
     private readonly EditSpecializationUseCase _useCase;
     private readonly IKnowledgeSpecializationRepository _specializationRepository;
     private readonly ICharacterKnowledgeRepository _mappingRepository;
+    private readonly ICharacterRepository _characterRepository;
+    private readonly ICharacterFactionRepository _characterFactionRepository;
     private readonly EditSpecializationModel _model;
     private readonly CharacterKnowledgeMapping _mappingDbModel;
     private readonly CharacterKnowledgeSpecialization _specializationDbModel;
@@ -26,13 +31,20 @@ public class EditSpecializationUseCaseTests
             Description = "Test Description",
             Notes = "567",
             Id = 1,
+            CharacterId = 1,
         };
 
-        _specializationDbModel = new CharacterKnowledgeSpecialization() { KnowledgeMappingId = 1 };
+        _specializationDbModel = new CharacterKnowledgeSpecialization()
+        {
+            KnowledgeMappingId = 1,
+            Name = "Old Specialization Name",
+        };
         _mappingDbModel = new CharacterKnowledgeMapping() { CharacterId = 1, KnowledgeId = 2 };
 
         _specializationRepository = A.Fake<IKnowledgeSpecializationRepository>();
         _mappingRepository = A.Fake<ICharacterKnowledgeRepository>();
+        _characterRepository = A.Fake<ICharacterRepository>();
+        _characterFactionRepository = A.Fake<ICharacterFactionRepository>();
 
         A.CallTo(() => _specializationRepository.GetSpecialization(_model.Id))
             .Returns(_specializationDbModel);
@@ -51,14 +63,19 @@ public class EditSpecializationUseCaseTests
                 )
             )
             .Returns(0);
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(true);
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns([]);
 
         var validator = new EditSpecializationModelValidator(
             _specializationRepository,
-            _mappingRepository
+            _mappingRepository,
+            _characterRepository
         );
 
         _useCase = new EditSpecializationUseCase(
             _specializationRepository,
+            _characterFactionRepository,
             validator,
             CancellationToken.None
         );
@@ -168,11 +185,109 @@ public class EditSpecializationUseCaseTests
     }
 
     [Fact]
+    public async Task ValidationFor_CharacterId_WillFail_WhenCharacterId_IsEmpty()
+    {
+        _model.CharacterId = 0;
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        results.MustHaveValidationError(
+            nameof(EditSpecializationModel.CharacterId),
+            "Character Id is required."
+        );
+    }
+
+    [Fact]
+    public async Task ValidationFor_CharacterId_WillFail_WhenCharacterDoesNotExist()
+    {
+        A.CallTo(() => _characterRepository.CharacterExistsAsync(_model.CharacterId)).Returns(false);
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        results.MustHaveValidationError(
+            nameof(EditSpecializationModel.CharacterId),
+            "This Character was not found."
+        );
+    }
+
+    [Fact]
     public async Task UseCase_CorrectlyGrabs_TheSpecialization()
     {
         await _useCase.ExecuteAsync(_model);
         A.CallTo(() => _specializationRepository.GetSpecialization(_model.Id))
             .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillGrab_TheLatestPlayerFactionLevels()
+    {
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UseCase_WillFail_WhenFactionLevelRequires_TheExistingKnowledgeSpecialization_AndNameChanges()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeSpecialization = "Old Specialization Name",
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        results.MustHaveValidationError(
+            nameof(EditSpecializationModel.Name),
+            "Your faction level prevents you from renaming this knowledge specialization"
+        );
+    }
+
+    [Fact]
+    public async Task UseCase_WillNotEdit_WhenFactionLevelRequires_TheExistingKnowledgeSpecialization_AndNameChanges()
+    {
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeSpecialization = "Old Specialization Name",
+                    },
+                ]
+            );
+
+        await _useCase.ExecuteAsync(_model);
+
+        A.CallTo(() =>
+                _specializationRepository.UpdateSpecialization(
+                    A<CharacterKnowledgeSpecialization>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task UseCase_WillAllowEdit_WhenFactionLevelRequires_TheExistingKnowledgeSpecialization_AndNameDoesNotChange()
+    {
+        _model.Name = "Old Specialization Name";
+        A.CallTo(() => _characterFactionRepository.GetLatestPlayerFactionLevels(_model.CharacterId))
+            .Returns(
+                [
+                    new CharacterFactionDto()
+                    {
+                        KnowledgeSpecialization = "Old Specialization Name",
+                    },
+                ]
+            );
+
+        var results = await _useCase.ExecuteAsync(_model);
+
+        Assert.True(results.IsSuccess);
     }
 
     [Fact]

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterModel.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterModel.cs
@@ -2,5 +2,6 @@ namespace ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.Delete;
 
 public class DeleteKnowledgeFromCharacterModel
 {
+    public int CharacterId { get; set; }
     public int MappingId { get; set; }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterModelValidator.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterModelValidator.cs
@@ -1,7 +1,5 @@
 using ExpressedRealms.Characters.Repository;
-using ExpressedRealms.Knowledges.Repository;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
-using ExpressedRealms.Knowledges.Repository.Knowledges;
 using FluentValidation;
 using JetBrains.Annotations;
 
@@ -12,7 +10,8 @@ internal sealed class DeleteKnowledgeFromCharacterModelValidator
     : AbstractValidator<DeleteKnowledgeFromCharacterModel>
 {
     public DeleteKnowledgeFromCharacterModelValidator(
-        ICharacterKnowledgeRepository mappingRepository
+        ICharacterKnowledgeRepository mappingRepository,
+        ICharacterRepository characterRepository
     )
     {
         RuleFor(x => x.MappingId)
@@ -20,5 +19,12 @@ internal sealed class DeleteKnowledgeFromCharacterModelValidator
             .WithMessage("Mapping Id is required.")
             .MustAsync(async (x, y) => await mappingRepository.MappingAlreadyExists(x))
             .WithMessage("The Knowledge Mapping does not exist.");
+        
+        RuleFor(x => x.CharacterId)
+            .NotEmpty()
+            .WithMessage("Character Id is required.")
+            .MustAsync(async (x, y) => await characterRepository.CharacterExistsAsync(x))
+            .WithMessage("NotFound")
+            .WithMessage("This Character was not found.");
     }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterModelValidator.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterModelValidator.cs
@@ -19,7 +19,7 @@ internal sealed class DeleteKnowledgeFromCharacterModelValidator
             .WithMessage("Mapping Id is required.")
             .MustAsync(async (x, y) => await mappingRepository.MappingAlreadyExists(x))
             .WithMessage("The Knowledge Mapping does not exist.");
-        
+
         RuleFor(x => x.CharacterId)
             .NotEmpty()
             .WithMessage("Character Id is required.")

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterUseCase.cs
@@ -27,13 +27,17 @@ internal sealed class DeleteKnowledgeFromCharacterUseCase(
         var mapping = await mappingRepository.GetCharacterKnowledgeMappingForEditing(
             model.MappingId
         );
-        
-        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
+
+        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(
+            model.CharacterId
+        );
 
         if (factionKnowledge.Any(x => x.KnowledgeId == mapping.KnowledgeId))
         {
-            return ValidationHelper.AddSingleValidationFailure(nameof(model.MappingId),
-                "Your faction level prevents you from removing this knowledge");
+            return ValidationHelper.AddSingleValidationFailure(
+                nameof(model.MappingId),
+                "Your faction level prevents you from removing this knowledge"
+            );
         }
 
         mapping.SoftDelete();

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Delete/DeleteKnowledgeFromCharacterUseCase.cs
@@ -1,6 +1,6 @@
 using ExpressedRealms.DB.Interceptors;
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
-using ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.Edit;
 using ExpressedRealms.UseCases.Shared;
 using FluentResults;
 
@@ -8,6 +8,7 @@ namespace ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.Delete;
 
 internal sealed class DeleteKnowledgeFromCharacterUseCase(
     ICharacterKnowledgeRepository mappingRepository,
+    ICharacterFactionRepository characterFactionRepository,
     DeleteKnowledgeFromCharacterModelValidator validator,
     CancellationToken cancellationToken
 ) : IDeleteKnowledgeFromCharacterUseCase
@@ -26,6 +27,14 @@ internal sealed class DeleteKnowledgeFromCharacterUseCase(
         var mapping = await mappingRepository.GetCharacterKnowledgeMappingForEditing(
             model.MappingId
         );
+        
+        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
+
+        if (factionKnowledge.Any(x => x.KnowledgeId == mapping.KnowledgeId))
+        {
+            return ValidationHelper.AddSingleValidationFailure(nameof(model.MappingId),
+                "Your faction level prevents you from removing this knowledge");
+        }
 
         mapping.SoftDelete();
 

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterModel.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterModel.cs
@@ -2,6 +2,7 @@ namespace ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.Edit;
 
 public class UpdateKnowledgeForCharacterModel
 {
+    public int CharacterId { get; set; }
     public int MappingId { get; set; }
     public int KnowledgeLevelId { get; set; }
     public string? Notes { get; set; }

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterModelValidator.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterModelValidator.cs
@@ -18,14 +18,13 @@ internal sealed class UpdateKnowledgeForCharacterModelValidator
         ICharacterRepository characterRepository
     )
     {
-        
         RuleFor(x => x.CharacterId)
             .NotEmpty()
             .WithMessage("Character Id is required.")
             .MustAsync(async (x, y) => await characterRepository.CharacterExistsAsync(x))
             .WithMessage("NotFound")
             .WithMessage("This Character was not found.");
-        
+
         RuleFor(x => x.MappingId)
             .NotEmpty()
             .WithMessage("Mapping Id is required.")

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterModelValidator.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterModelValidator.cs
@@ -14,9 +14,18 @@ internal sealed class UpdateKnowledgeForCharacterModelValidator
     public UpdateKnowledgeForCharacterModelValidator(
         IKnowledgeRepository knowledgeRepository,
         ICharacterKnowledgeRepository mappingRepository,
-        IKnowledgeLevelRepository knowledgeLevelRepository
+        IKnowledgeLevelRepository knowledgeLevelRepository,
+        ICharacterRepository characterRepository
     )
     {
+        
+        RuleFor(x => x.CharacterId)
+            .NotEmpty()
+            .WithMessage("Character Id is required.")
+            .MustAsync(async (x, y) => await characterRepository.CharacterExistsAsync(x))
+            .WithMessage("NotFound")
+            .WithMessage("This Character was not found.");
+        
         RuleFor(x => x.MappingId)
             .NotEmpty()
             .WithMessage("Mapping Id is required.")

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterUseCase.cs
@@ -39,7 +39,7 @@ internal sealed class UpdateKnowledgeForCharacterUseCase(
         {
             var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
             // This only works because knowledge level ids are in order
-            if (factionKnowledge.Any(x => x.KnowledgeLevel?.Id < model.KnowledgeLevelId))
+            if (factionKnowledge.Any(x => x.KnowledgeLevel != null && x.KnowledgeLevel?.Id > model.KnowledgeLevelId))
             {
                 return ValidationHelper.AddSingleValidationFailure(nameof(model.KnowledgeLevelId),
                     "Your faction level prevents you from applying this knowledge level change.");

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterUseCase.cs
@@ -37,14 +37,24 @@ internal sealed class UpdateKnowledgeForCharacterUseCase(
 
         if (mapping.KnowledgeLevelId != model.KnowledgeLevelId)
         {
-            var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
+            var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(
+                model.CharacterId
+            );
             // This only works because knowledge level ids are in order
-            if (factionKnowledge.Any(x => x.KnowledgeLevel != null && x.KnowledgeLevel?.Id > model.KnowledgeLevelId && x.KnowledgeId == mapping.KnowledgeId))
+            if (
+                factionKnowledge.Any(x =>
+                    x.KnowledgeLevel != null
+                    && x.KnowledgeLevel?.Id > model.KnowledgeLevelId
+                    && x.KnowledgeId == mapping.KnowledgeId
+                )
+            )
             {
-                return ValidationHelper.AddSingleValidationFailure(nameof(model.KnowledgeLevelId),
-                    "Your faction level prevents you from applying this knowledge level change.");
+                return ValidationHelper.AddSingleValidationFailure(
+                    nameof(model.KnowledgeLevelId),
+                    "Your faction level prevents you from applying this knowledge level change."
+                );
             }
-            
+
             var xpInfo = await xpRepository.GetAvailableXpForSection(
                 mapping.CharacterId,
                 XpSectionTypes.Knowledge

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterUseCase.cs
@@ -1,5 +1,6 @@
 using ExpressedRealms.Characters.Repository.Xp;
 using ExpressedRealms.DB.Models.Characters.XpTables;
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
 using ExpressedRealms.Knowledges.Repository;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.Repository.Knowledges;
@@ -13,6 +14,7 @@ internal sealed class UpdateKnowledgeForCharacterUseCase(
     ICharacterKnowledgeRepository mappingRepository,
     IKnowledgeLevelRepository knowledgeLevelRepository,
     IKnowledgeRepository knowledgeRepository,
+    ICharacterFactionRepository characterFactionRepository,
     IXpRepository xpRepository,
     UpdateKnowledgeForCharacterModelValidator validator,
     CancellationToken cancellationToken
@@ -35,6 +37,14 @@ internal sealed class UpdateKnowledgeForCharacterUseCase(
 
         if (mapping.KnowledgeLevelId != model.KnowledgeLevelId)
         {
+            var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
+            // This only works because knowledge level ids are in order
+            if (factionKnowledge.Any(x => x.KnowledgeLevel?.Id < model.KnowledgeLevelId))
+            {
+                return ValidationHelper.AddSingleValidationFailure(nameof(model.KnowledgeLevelId),
+                    "Your faction level prevents you from applying this knowledge level change.");
+            }
+            
             var xpInfo = await xpRepository.GetAvailableXpForSection(
                 mapping.CharacterId,
                 XpSectionTypes.Knowledge

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/Edit/UpdateKnowledgeForCharacterUseCase.cs
@@ -39,7 +39,7 @@ internal sealed class UpdateKnowledgeForCharacterUseCase(
         {
             var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
             // This only works because knowledge level ids are in order
-            if (factionKnowledge.Any(x => x.KnowledgeLevel != null && x.KnowledgeLevel?.Id > model.KnowledgeLevelId))
+            if (factionKnowledge.Any(x => x.KnowledgeLevel != null && x.KnowledgeLevel?.Id > model.KnowledgeLevelId && x.KnowledgeId == mapping.KnowledgeId))
             {
                 return ValidationHelper.AddSingleValidationFailure(nameof(model.KnowledgeLevelId),
                     "Your faction level prevents you from applying this knowledge level change.");

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/CharacterKnowledgeReturnModel.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/CharacterKnowledgeReturnModel.cs
@@ -1,5 +1,3 @@
-using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings.Projections;
-
 namespace ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.GetReadOnly;
 
 public class CharacterKnowledgeReturnModel
@@ -13,4 +11,6 @@ public class CharacterKnowledgeReturnModel
     public string? Notes { get; set; }
     public int LevelId { get; set; }
     public int SpecializationCount { get; set; }
+    public bool CanSelectLevel { get; set; }
+    public int? MinimumKnowledgeId { get; set; }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/GetKnowledgesForCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/GetKnowledgesForCharacterUseCase.cs
@@ -54,7 +54,7 @@ internal sealed class GetKnowledgesForCharacterUseCase(
                         Description = y.Description,
                         Id = y.Id,
                         Notes = y.Notes,
-                        BlockFactionChanges = characterFactionLevels.Any(z => z.KnowledgeSpecialization == y.Name)
+                        BlockFactionChanges = characterFactionLevels.Any(z => z.KnowledgeSpecialization == y.Name && z.KnowledgeId == x.Knowledge.Id)
                     })
                     .ToList(),
             })

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/GetKnowledgesForCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/GetKnowledgesForCharacterUseCase.cs
@@ -1,3 +1,4 @@
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.UseCases.Shared;
 using FluentResults;
@@ -6,6 +7,7 @@ namespace ExpressedRealms.Knowledges.UseCases.CharacterKnowledgeMappings.GetRead
 
 internal sealed class GetKnowledgesForCharacterUseCase(
     ICharacterKnowledgeRepository mappingRepository,
+    ICharacterFactionRepository characterFactionRepository,
     GetKnowledgesForCharacterModelValidator validator,
     CancellationToken cancellationToken
 ) : IGetKnowledgesForCharacterUseCase
@@ -24,6 +26,7 @@ internal sealed class GetKnowledgesForCharacterUseCase(
             return Result.Fail(result.Errors);
 
         var knowledges = await mappingRepository.GetKnowledgesForCharacter(model.CharacterId);
+        var characterFactionLevels = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
 
         var items = knowledges
             .Select(x => new CharacterKnowledgeReturnModel()
@@ -35,6 +38,7 @@ internal sealed class GetKnowledgesForCharacterUseCase(
                     Name = x.Knowledge.Name,
                     Description = x.Knowledge.Description,
                     Type = x.Knowledge.Type,
+                    BlockFactionChanges = characterFactionLevels.All(y => y.KnowledgeId != x.Knowledge.Id)
                 },
                 StoneModifier = x.StoneModifier,
                 LevelName = x.LevelName,
@@ -42,6 +46,7 @@ internal sealed class GetKnowledgesForCharacterUseCase(
                 LevelId = x.LevelId,
                 Notes = x.Notes,
                 SpecializationCount = x.SpecializationCount,
+                MinimumKnowledgeId = characterFactionLevels.Where(y => y.KnowledgeId == x.Knowledge.Id).Max(y => y.KnowledgeLevel?.Id),
                 Specializations = x
                     .Specializations.Select(y => new SpecializationReturnModel()
                     {
@@ -49,10 +54,13 @@ internal sealed class GetKnowledgesForCharacterUseCase(
                         Description = y.Description,
                         Id = y.Id,
                         Notes = y.Notes,
+                        BlockFactionChanges = characterFactionLevels.Any(z => z.KnowledgeSpecialization == y.Name)
                     })
                     .ToList(),
             })
             .ToList();
+        
+        
 
         return Result.Ok(items.ToList());
     }

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/GetKnowledgesForCharacterUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/GetKnowledgesForCharacterUseCase.cs
@@ -26,7 +26,9 @@ internal sealed class GetKnowledgesForCharacterUseCase(
             return Result.Fail(result.Errors);
 
         var knowledges = await mappingRepository.GetKnowledgesForCharacter(model.CharacterId);
-        var characterFactionLevels = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
+        var characterFactionLevels = await characterFactionRepository.GetLatestPlayerFactionLevels(
+            model.CharacterId
+        );
 
         var items = knowledges
             .Select(x => new CharacterKnowledgeReturnModel()
@@ -38,7 +40,9 @@ internal sealed class GetKnowledgesForCharacterUseCase(
                     Name = x.Knowledge.Name,
                     Description = x.Knowledge.Description,
                     Type = x.Knowledge.Type,
-                    BlockFactionChanges = characterFactionLevels.All(y => y.KnowledgeId != x.Knowledge.Id)
+                    BlockFactionChanges = characterFactionLevels.All(y =>
+                        y.KnowledgeId != x.Knowledge.Id
+                    ),
                 },
                 StoneModifier = x.StoneModifier,
                 LevelName = x.LevelName,
@@ -46,7 +50,9 @@ internal sealed class GetKnowledgesForCharacterUseCase(
                 LevelId = x.LevelId,
                 Notes = x.Notes,
                 SpecializationCount = x.SpecializationCount,
-                MinimumKnowledgeId = characterFactionLevels.Where(y => y.KnowledgeId == x.Knowledge.Id).Max(y => y.KnowledgeLevel?.Id),
+                MinimumKnowledgeId = characterFactionLevels
+                    .Where(y => y.KnowledgeId == x.Knowledge.Id)
+                    .Max(y => y.KnowledgeLevel?.Id),
                 Specializations = x
                     .Specializations.Select(y => new SpecializationReturnModel()
                     {
@@ -54,13 +60,13 @@ internal sealed class GetKnowledgesForCharacterUseCase(
                         Description = y.Description,
                         Id = y.Id,
                         Notes = y.Notes,
-                        BlockFactionChanges = characterFactionLevels.Any(z => z.KnowledgeSpecialization == y.Name && z.KnowledgeId == x.Knowledge.Id)
+                        BlockFactionChanges = characterFactionLevels.Any(z =>
+                            z.KnowledgeSpecialization == y.Name && z.KnowledgeId == x.Knowledge.Id
+                        ),
                     })
                     .ToList(),
             })
             .ToList();
-        
-        
 
         return Result.Ok(items.ToList());
     }

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/KnowledgeReturnModel.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/KnowledgeReturnModel.cs
@@ -6,4 +6,5 @@ public class KnowledgeReturnModel
     public required string Description { get; set; }
     public required string Type { get; set; }
     public int Id { get; set; }
+    public bool BlockFactionChanges { get; set; }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/SpecializationReturnModel.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/SpecializationReturnModel.cs
@@ -6,4 +6,8 @@ public class SpecializationReturnModel
     public required string Name { get; set; }
     public required string Description { get; set; }
     public string? Notes { get; set; }
+    /// <summary>
+    /// This should block the ability to edit the name and delete the specialization
+    /// </summary>
+    public bool BlockFactionChanges { get; set; }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/SpecializationReturnModel.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/CharacterKnowledgeMappings/GetReadOnly/SpecializationReturnModel.cs
@@ -6,6 +6,7 @@ public class SpecializationReturnModel
     public required string Name { get; set; }
     public required string Description { get; set; }
     public string? Notes { get; set; }
+
     /// <summary>
     /// This should block the ability to edit the name and delete the specialization
     /// </summary>

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationModel.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationModel.cs
@@ -3,4 +3,5 @@ namespace ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.DeleteSpe
 public class DeleteSpecializationModel
 {
     public int Id { get; set; }
+    public int CharacterId { get; set; }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationModelValidator.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationModelValidator.cs
@@ -1,3 +1,4 @@
+using ExpressedRealms.Characters.Repository;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
 using FluentValidation;
 using JetBrains.Annotations;
@@ -8,7 +9,7 @@ namespace ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.DeleteSpe
 internal sealed class DeleteSpecializationModelValidator
     : AbstractValidator<DeleteSpecializationModel>
 {
-    public DeleteSpecializationModelValidator(IKnowledgeSpecializationRepository repository)
+    public DeleteSpecializationModelValidator(IKnowledgeSpecializationRepository repository, ICharacterRepository characterRepository)
     {
         RuleFor(x => x.Id)
             .NotEmpty()
@@ -16,5 +17,12 @@ internal sealed class DeleteSpecializationModelValidator
             .MustAsync(async (x, y) => await repository.SpecializationExists(x))
             .WithMessage("NotFound")
             .WithMessage("This Specialization was not found.");
+        
+        RuleFor(x => x.CharacterId)
+            .NotEmpty()
+            .WithMessage("Character Id is required.")
+            .MustAsync(async (x, y) => await characterRepository.CharacterExistsAsync(x))
+            .WithMessage("NotFound")
+            .WithMessage("This Character was not found.");
     }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationModelValidator.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationModelValidator.cs
@@ -9,7 +9,10 @@ namespace ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.DeleteSpe
 internal sealed class DeleteSpecializationModelValidator
     : AbstractValidator<DeleteSpecializationModel>
 {
-    public DeleteSpecializationModelValidator(IKnowledgeSpecializationRepository repository, ICharacterRepository characterRepository)
+    public DeleteSpecializationModelValidator(
+        IKnowledgeSpecializationRepository repository,
+        ICharacterRepository characterRepository
+    )
     {
         RuleFor(x => x.Id)
             .NotEmpty()
@@ -17,7 +20,7 @@ internal sealed class DeleteSpecializationModelValidator
             .MustAsync(async (x, y) => await repository.SpecializationExists(x))
             .WithMessage("NotFound")
             .WithMessage("This Specialization was not found.");
-        
+
         RuleFor(x => x.CharacterId)
             .NotEmpty()
             .WithMessage("Character Id is required.")

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationUseCase.cs
@@ -1,7 +1,6 @@
 using ExpressedRealms.DB.Interceptors;
-using ExpressedRealms.Knowledges.Repository.Knowledges;
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
-using ExpressedRealms.Knowledges.UseCases.Knowledges.DeleteKnowledge;
 using ExpressedRealms.UseCases.Shared;
 using FluentResults;
 
@@ -9,6 +8,7 @@ namespace ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.DeleteSpe
 
 internal sealed class DeleteSpecializationUseCase(
     IKnowledgeSpecializationRepository knowledgeRepository,
+    ICharacterFactionRepository characterFactionRepository,
     DeleteSpecializationModelValidator validator,
     CancellationToken cancellationToken
 ) : IDeleteSpecializationUseCase
@@ -25,6 +25,13 @@ internal sealed class DeleteSpecializationUseCase(
             return Result.Fail(result.Errors);
 
         var knowledge = await knowledgeRepository.GetSpecialization(model.Id);
+        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
+
+        if (factionKnowledge.Any(x => x.KnowledgeSpecialization == knowledge.Name))
+        {
+            return ValidationHelper.AddSingleValidationFailure(nameof(model.Id),
+                "Your faction level prevents you from removing this knowledge specialization");
+        }
 
         knowledge.SoftDelete();
 

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationUseCase.cs
@@ -28,13 +28,24 @@ internal sealed class DeleteSpecializationUseCase(
 
         var specialization = await knowledgeRepository.GetSpecialization(model.Id);
         var characterMapping =
-            await characterKnowledgeRepository.GetCharacterKnowledgeMappingForEditing(specialization.KnowledgeMappingId);
-        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
+            await characterKnowledgeRepository.GetCharacterKnowledgeMappingForEditing(
+                specialization.KnowledgeMappingId
+            );
+        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(
+            model.CharacterId
+        );
 
-        if (factionKnowledge.Any(x => x.KnowledgeSpecialization == specialization.Name && x.KnowledgeId == characterMapping.KnowledgeId))
+        if (
+            factionKnowledge.Any(x =>
+                x.KnowledgeSpecialization == specialization.Name
+                && x.KnowledgeId == characterMapping.KnowledgeId
+            )
+        )
         {
-            return ValidationHelper.AddSingleValidationFailure(nameof(model.Id),
-                "Your faction level prevents you from removing this knowledge specialization");
+            return ValidationHelper.AddSingleValidationFailure(
+                nameof(model.Id),
+                "Your faction level prevents you from removing this knowledge specialization"
+            );
         }
 
         specialization.SoftDelete();

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/DeleteSpecialization/DeleteSpecializationUseCase.cs
@@ -1,5 +1,6 @@
 using ExpressedRealms.DB.Interceptors;
 using ExpressedRealms.Expressions.Repository.CharacterFactions;
+using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
 using ExpressedRealms.UseCases.Shared;
 using FluentResults;
@@ -9,6 +10,7 @@ namespace ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.DeleteSpe
 internal sealed class DeleteSpecializationUseCase(
     IKnowledgeSpecializationRepository knowledgeRepository,
     ICharacterFactionRepository characterFactionRepository,
+    ICharacterKnowledgeRepository characterKnowledgeRepository,
     DeleteSpecializationModelValidator validator,
     CancellationToken cancellationToken
 ) : IDeleteSpecializationUseCase
@@ -24,18 +26,20 @@ internal sealed class DeleteSpecializationUseCase(
         if (result.IsFailed)
             return Result.Fail(result.Errors);
 
-        var knowledge = await knowledgeRepository.GetSpecialization(model.Id);
+        var specialization = await knowledgeRepository.GetSpecialization(model.Id);
+        var characterMapping =
+            await characterKnowledgeRepository.GetCharacterKnowledgeMappingForEditing(specialization.KnowledgeMappingId);
         var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
 
-        if (factionKnowledge.Any(x => x.KnowledgeSpecialization == knowledge.Name))
+        if (factionKnowledge.Any(x => x.KnowledgeSpecialization == specialization.Name && x.KnowledgeId == characterMapping.KnowledgeId))
         {
             return ValidationHelper.AddSingleValidationFailure(nameof(model.Id),
                 "Your faction level prevents you from removing this knowledge specialization");
         }
 
-        knowledge.SoftDelete();
+        specialization.SoftDelete();
 
-        await knowledgeRepository.UpdateSpecialization(knowledge);
+        await knowledgeRepository.UpdateSpecialization(specialization);
 
         return Result.Ok();
     }

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationModel.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationModel.cs
@@ -2,6 +2,7 @@ namespace ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.EditSpeci
 
 public class EditSpecializationModel
 {
+    public int CharacterId { get; set; }
     public required string Name { get; set; }
     public required string Description { get; set; }
     public int Id { get; set; }

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationModelValidator.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationModelValidator.cs
@@ -46,7 +46,7 @@ internal sealed class EditSpecializationModelValidator : AbstractValidator<EditS
             .WithMessage("Id is required.")
             .MustAsync(async (x, y) => await specializationRepository.SpecializationExists(x))
             .WithMessage("The Specialization does not exist.");
-        
+
         RuleFor(x => x.CharacterId)
             .NotEmpty()
             .WithMessage("Character Id is required.")

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationModelValidator.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationModelValidator.cs
@@ -1,3 +1,4 @@
+using ExpressedRealms.Characters.Repository;
 using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
 using ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.CreateSpecialization;
@@ -11,7 +12,8 @@ internal sealed class EditSpecializationModelValidator : AbstractValidator<EditS
 {
     public EditSpecializationModelValidator(
         IKnowledgeSpecializationRepository specializationRepository,
-        ICharacterKnowledgeRepository mappingRepository
+        ICharacterKnowledgeRepository mappingRepository,
+        ICharacterRepository characterRepository
     )
     {
         RuleFor(x => x.Name)
@@ -44,5 +46,12 @@ internal sealed class EditSpecializationModelValidator : AbstractValidator<EditS
             .WithMessage("Id is required.")
             .MustAsync(async (x, y) => await specializationRepository.SpecializationExists(x))
             .WithMessage("The Specialization does not exist.");
+        
+        RuleFor(x => x.CharacterId)
+            .NotEmpty()
+            .WithMessage("Character Id is required.")
+            .MustAsync(async (x, y) => await characterRepository.CharacterExistsAsync(x))
+            .WithMessage("NotFound")
+            .WithMessage("This Character was not found.");
     }
 }

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationUseCase.cs
@@ -26,15 +26,27 @@ internal sealed class EditSpecializationUseCase(
             return Result.Fail(result.Errors);
 
         var specialization = await specializationRepository.GetSpecialization(model.Id);
-        
-        var characterMapping =
-            await characterKnowledgeRepository.GetCharacterKnowledgeMappingForEditing(specialization.KnowledgeMappingId);
-        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
 
-        if (factionKnowledge.Any(x => x.KnowledgeSpecialization == specialization.Name && specialization.Name != model.Name && x.KnowledgeId == characterMapping.KnowledgeId))
+        var characterMapping =
+            await characterKnowledgeRepository.GetCharacterKnowledgeMappingForEditing(
+                specialization.KnowledgeMappingId
+            );
+        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(
+            model.CharacterId
+        );
+
+        if (
+            factionKnowledge.Any(x =>
+                x.KnowledgeSpecialization == specialization.Name
+                && specialization.Name != model.Name
+                && x.KnowledgeId == characterMapping.KnowledgeId
+            )
+        )
         {
-            return ValidationHelper.AddSingleValidationFailure(nameof(model.Name),
-                "Your faction level prevents you from renaming this knowledge specialization");
+            return ValidationHelper.AddSingleValidationFailure(
+                nameof(model.Name),
+                "Your faction level prevents you from renaming this knowledge specialization"
+            );
         }
 
         specialization.Name = model.Name;

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationUseCase.cs
@@ -1,4 +1,5 @@
 using ExpressedRealms.Expressions.Repository.CharacterFactions;
+using ExpressedRealms.Knowledges.Repository.CharacterKnowledgeMappings;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
 using ExpressedRealms.UseCases.Shared;
 using FluentResults;
@@ -8,6 +9,7 @@ namespace ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.EditSpeci
 internal sealed class EditSpecializationUseCase(
     IKnowledgeSpecializationRepository specializationRepository,
     ICharacterFactionRepository characterFactionRepository,
+    ICharacterKnowledgeRepository characterKnowledgeRepository,
     EditSpecializationModelValidator validator,
     CancellationToken cancellationToken
 ) : IEditSpecializationUseCase
@@ -24,9 +26,12 @@ internal sealed class EditSpecializationUseCase(
             return Result.Fail(result.Errors);
 
         var specialization = await specializationRepository.GetSpecialization(model.Id);
+        
+        var characterMapping =
+            await characterKnowledgeRepository.GetCharacterKnowledgeMappingForEditing(specialization.KnowledgeMappingId);
         var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
 
-        if (factionKnowledge.Any(x => x.KnowledgeSpecialization == specialization.Name && specialization.Name != model.Name))
+        if (factionKnowledge.Any(x => x.KnowledgeSpecialization == specialization.Name && specialization.Name != model.Name && x.KnowledgeId == characterMapping.KnowledgeId))
         {
             return ValidationHelper.AddSingleValidationFailure(nameof(model.Name),
                 "Your faction level prevents you from renaming this knowledge specialization");

--- a/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationUseCase.cs
+++ b/api/ExpressedRealms.Knowledges.UseCases/KnowledgeSpecializations/EditSpecialization/EditSpecializationUseCase.cs
@@ -1,3 +1,4 @@
+using ExpressedRealms.Expressions.Repository.CharacterFactions;
 using ExpressedRealms.Knowledges.Repository.KnowledgeSpecializations;
 using ExpressedRealms.UseCases.Shared;
 using FluentResults;
@@ -6,6 +7,7 @@ namespace ExpressedRealms.Knowledges.UseCases.KnowledgeSpecializations.EditSpeci
 
 internal sealed class EditSpecializationUseCase(
     IKnowledgeSpecializationRepository specializationRepository,
+    ICharacterFactionRepository characterFactionRepository,
     EditSpecializationModelValidator validator,
     CancellationToken cancellationToken
 ) : IEditSpecializationUseCase
@@ -22,6 +24,13 @@ internal sealed class EditSpecializationUseCase(
             return Result.Fail(result.Errors);
 
         var specialization = await specializationRepository.GetSpecialization(model.Id);
+        var factionKnowledge = await characterFactionRepository.GetLatestPlayerFactionLevels(model.CharacterId);
+
+        if (factionKnowledge.Any(x => x.KnowledgeSpecialization == specialization.Name && specialization.Name != model.Name))
+        {
+            return ValidationHelper.AddSingleValidationFailure(nameof(model.Name),
+                "Your faction level prevents you from renaming this knowledge specialization");
+        }
 
         specialization.Name = model.Name;
         specialization.Description = model.Description;

--- a/client/src/components/characters/character/knowledges/types.ts
+++ b/client/src/components/characters/character/knowledges/types.ts
@@ -9,15 +9,18 @@ export interface CharacterKnowledge {
   notes: string | null
   level: number
   levelId: number
+  minimumKnowledgeId: number
   specializationCount: number
   knowledge: Knowledge
   specializations: Array<Specialization>
 }
 
 export interface Knowledge {
+  id: number
   name: string
   description: string
   type: string
+  blockFactionChanges: boolean
 }
 
 export interface Specialization {
@@ -25,6 +28,7 @@ export interface Specialization {
   name: string
   description: string
   notes: string | null
+  blockFactionChanges: boolean
 }
 
 export interface KnowledgeOptionResponse {

--- a/client/src/components/characters/wizard/knowledges/EditCharacterKnowledge.vue
+++ b/client/src/components/characters/wizard/knowledges/EditCharacterKnowledge.vue
@@ -65,7 +65,8 @@ async function loadInfo() {
       xpCost = level.totalGeneralXpCost - getCurrentXpLevel(knowledge.value.levelId)
     }
 
-    level.disabled = xpCost > sectionInfo.value.availableXp && isLowerLevel
+    const factionRequirementMinimum = knowledge.value.minimumKnowledgeId > level.id
+    level.disabled = xpCost > sectionInfo.value.availableXp && isLowerLevel || factionRequirementMinimum
     return level
   })
 
@@ -110,7 +111,7 @@ const onRowUnselect = (event) => {
         <div>{{ knowledge.knowledge.type }}</div>
       </div>
       <div class="p-0 m-2 d-inline-flex align-items-start align-items-center gap-2">
-        <Button label="Delete" size="small" severity="danger" @click="popupService.deleteConfirmation($event, knowledge.mappingId )" />
+        <Button v-if="knowledge.knowledge.blockFactionChanges" label="Delete" size="small" severity="danger" @click="popupService.deleteConfirmation($event, knowledge.mappingId )" />
         <Button label="Update" size="small" type="submit" />
       </div>
     </div>
@@ -122,6 +123,11 @@ const onRowUnselect = (event) => {
     <div v-if="sectionInfo.availableXp == 0">
       <Message severity="warn" class="my-4">
         You are out of experience to spend on Knowledges.
+      </Message>
+    </div>
+    <div v-if="!knowledge.knowledge.blockFactionChanges">
+      <Message severity="warn" class="my-4">
+        Your faction level affects the levels you can choose below
       </Message>
     </div>
     <DataTable
@@ -180,7 +186,7 @@ const onRowUnselect = (event) => {
       </p>
 
       <div class="p-0 m-0 d-flex justify-content-between">
-        <Button label="Delete" severity="danger" @click="popupService.deleteSpecializationConfirmation($event, knowledge.mappingId, special.id)" />
+        <Button v-if="!special.blockFactionChanges" label="Delete" severity="danger" @click="popupService.deleteSpecializationConfirmation($event, knowledge.mappingId, special.id)" />
         <Button label="Edit" @click="dialogService.showEditSpecialization(knowledge, special)" />
       </div>
     </div>

--- a/client/src/components/characters/wizard/knowledges/EditSpecializationKnowledge.vue
+++ b/client/src/components/characters/wizard/knowledges/EditSpecializationKnowledge.vue
@@ -45,7 +45,11 @@ const onSubmit = form.handleSubmit(async (values) => {
 
   <h2>Specialization</h2>
   <form @submit="onSubmit">
-    <FormInputTextWrapper v-model="form.name" />
+    <FormInputTextWrapper v-model="form.name" :is-disabled="specialization.blockFactionChanges" />
+
+    <p v-if="specialization.blockFactionChanges">
+      You cannot change this specialization name due to faction requirements.
+    </p>
 
     <FormTextAreaWrapper v-model="form.description" />
 


### PR DESCRIPTION
Character Knowledge UI + API now takes into consideration Faction level info

Will prevent renaming of specializations, the deletion of a specialization, lowering the level of a knowledge, and deleting the knowledge