### PR TITLE
Add Character Modifiers

### DIFF
--- a/api/ExpressedRealms.Authentication/PermissionCollection/CharacterManagementResource.cs
+++ b/api/ExpressedRealms.Authentication/PermissionCollection/CharacterManagementResource.cs
@@ -47,5 +47,12 @@ public static partial class Permissions
             Name = nameof(ModifyGoFields),
             Description = "Allows one to modify wealth levels and Prima/Void",
         };
+        
+        public static readonly Permission EditModifiers = new(ResourceInfo)
+        {
+            Id = new Guid("019fe0c2-752d-712e-b6c0-642607a20bf5"),
+            Name = nameof(EditModifiers),
+            Description = "Allows one to adhoc add modifiers to the character",
+        };
     }
 }

--- a/api/ExpressedRealms.Authentication/PermissionCollection/CharacterManagementResource.cs
+++ b/api/ExpressedRealms.Authentication/PermissionCollection/CharacterManagementResource.cs
@@ -47,7 +47,7 @@ public static partial class Permissions
             Name = nameof(ModifyGoFields),
             Description = "Allows one to modify wealth levels and Prima/Void",
         };
-        
+
         public static readonly Permission EditModifiers = new(ResourceInfo)
         {
             Id = new Guid("019fe0c2-752d-712e-b6c0-642607a20bf5"),

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetCharacterGoFields/GetCharacterGoFieldsEndpoint.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetCharacterGoFields/GetCharacterGoFieldsEndpoint.cs
@@ -29,7 +29,7 @@ internal static class GetCharacterGoFieldsEndpoint
                 Motes = response.Value.Motes,
                 PrimaFragments = response.Value.PrimaFragments,
                 VoidFragments = response.Value.VoidFragments,
-                StatModifierGroupId = response.Value.StatModifierGroupId
+                StatModifierGroupId = response.Value.StatModifierGroupId,
             }
         );
     }

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetCharacterGoFields/GetCharacterGoFieldsEndpoint.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetCharacterGoFields/GetCharacterGoFieldsEndpoint.cs
@@ -29,6 +29,7 @@ internal static class GetCharacterGoFieldsEndpoint
                 Motes = response.Value.Motes,
                 PrimaFragments = response.Value.PrimaFragments,
                 VoidFragments = response.Value.VoidFragments,
+                StatModifierGroupId = response.Value.StatModifierGroupId
             }
         );
     }

--- a/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetCharacterGoFields/GetCharacterGoFieldsResponse.cs
+++ b/api/ExpressedRealms.Characters.API/CharacterEndPoints/GetCharacterGoFields/GetCharacterGoFieldsResponse.cs
@@ -6,4 +6,5 @@ internal record GetCharacterGoFieldsResponse
     public int VoidFragments { get; set; }
     public int Motes { get; set; }
     public int PrimaFragments { get; set; }
+    public int? StatModifierGroupId { get; set; }
 }

--- a/api/ExpressedRealms.Characters.Repository/Proficiencies/ProficiencyRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/Proficiencies/ProficiencyRepository.cs
@@ -118,7 +118,7 @@ internal sealed class ProficiencyRepository(
             )
         );
         dbModifiers.AddRange(await statModifierRepository.GetModifiersFromCharacter(characterId));
-        
+
         dbModifiers = dbModifiers
             .Where(x =>
                 x.TargetExpressionId == null || x.TargetExpressionId == character.ExpressionId

--- a/api/ExpressedRealms.Characters.Repository/Proficiencies/ProficiencyRepository.cs
+++ b/api/ExpressedRealms.Characters.Repository/Proficiencies/ProficiencyRepository.cs
@@ -117,6 +117,8 @@ internal sealed class ProficiencyRepository(
                 character.PrimaryProgressionId
             )
         );
+        dbModifiers.AddRange(await statModifierRepository.GetModifiersFromCharacter(characterId));
+        
         dbModifiers = dbModifiers
             .Where(x =>
                 x.TargetExpressionId == null || x.TargetExpressionId == character.ExpressionId

--- a/api/ExpressedRealms.Characters.UseCases/Characters/GetCharacterGoFields/GetCharacterGoFieldReturnModel.cs
+++ b/api/ExpressedRealms.Characters.UseCases/Characters/GetCharacterGoFields/GetCharacterGoFieldReturnModel.cs
@@ -6,4 +6,5 @@ public class GetCharacterGoFieldReturnModel
     public int VoidFragments { get; set; }
     public int Motes { get; set; }
     public int PrimaFragments { get; set; }
+    public int? StatModifierGroupId { get; set; }
 }

--- a/api/ExpressedRealms.Characters.UseCases/Characters/GetCharacterGoFields/GetCharacterGoFieldsUseCase.cs
+++ b/api/ExpressedRealms.Characters.UseCases/Characters/GetCharacterGoFields/GetCharacterGoFieldsUseCase.cs
@@ -32,6 +32,7 @@ internal sealed class GetCharacterGoFieldsUseCase(
                 VoidFragments = character.VoidFragments,
                 Motes = character.Motes,
                 PrimaFragments = character.PrimaFragments,
+                StatModifierGroupId = character.StatModifierGroupId
             }
         );
     }

--- a/api/ExpressedRealms.Characters.UseCases/Characters/GetCharacterGoFields/GetCharacterGoFieldsUseCase.cs
+++ b/api/ExpressedRealms.Characters.UseCases/Characters/GetCharacterGoFields/GetCharacterGoFieldsUseCase.cs
@@ -32,7 +32,7 @@ internal sealed class GetCharacterGoFieldsUseCase(
                 VoidFragments = character.VoidFragments,
                 Motes = character.Motes,
                 PrimaFragments = character.PrimaFragments,
-                StatModifierGroupId = character.StatModifierGroupId
+                StatModifierGroupId = character.StatModifierGroupId,
             }
         );
     }

--- a/api/ExpressedRealms.DB/Migrations/20260808091625_AddStatModifierGroupIdToCharacters.Designer.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260808091625_AddStatModifierGroupIdToCharacters.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ExpressedRealms.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ExpressedRealms.DB.Migrations
 {
     [DbContext(typeof(ExpressedRealmsDbContext))]
-    partial class ExpressedRealmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808091625_AddStatModifierGroupIdToCharacters")]
+    partial class AddStatModifierGroupIdToCharacters
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/ExpressedRealms.DB/Migrations/20260808091625_AddStatModifierGroupIdToCharacters.cs
+++ b/api/ExpressedRealms.DB/Migrations/20260808091625_AddStatModifierGroupIdToCharacters.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpressedRealms.DB.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStatModifierGroupIdToCharacters : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "stat_modifier_group_id",
+                table: "characters",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_characters_stat_modifier_group_id",
+                table: "characters",
+                column: "stat_modifier_group_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_characters_stat_modifier_groups_stat_modifier_group_id",
+                table: "characters",
+                column: "stat_modifier_group_id",
+                principalTable: "stat_modifier_groups",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_characters_stat_modifier_groups_stat_modifier_group_id",
+                table: "characters");
+
+            migrationBuilder.DropIndex(
+                name: "ix_characters_stat_modifier_group_id",
+                table: "characters");
+
+            migrationBuilder.DropColumn(
+                name: "stat_modifier_group_id",
+                table: "characters");
+        }
+    }
+}

--- a/api/ExpressedRealms.DB/Models/Characters/Character.cs
+++ b/api/ExpressedRealms.DB/Models/Characters/Character.cs
@@ -45,10 +45,10 @@ public class Character : ISoftDelete
     public int? SecondaryProgressionId { get; set; }
     public virtual ProgressionPath? PrimaryProgressionPath { get; set; }
     public virtual ProgressionPath? SecondaryProgressionPath { get; set; }
-    
+
     public int? StatModifierGroupId { get; set; }
     public StatModifierGroup? StatModifierGroup { get; set; }
-    
+
     public bool IsDeleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
 

--- a/api/ExpressedRealms.DB/Models/Characters/Character.cs
+++ b/api/ExpressedRealms.DB/Models/Characters/Character.cs
@@ -9,6 +9,7 @@ using ExpressedRealms.DB.Models.Expressions.ExpressionSetup;
 using ExpressedRealms.DB.Models.Expressions.ProgressionPathSetup.ProgressionPaths;
 using ExpressedRealms.DB.Models.Factions.CharacterFactionMappingModels;
 using ExpressedRealms.DB.Models.Knowledges.CharacterKnowledgeMappings;
+using ExpressedRealms.DB.Models.ModifierSystem.StatModifierGroups;
 using ExpressedRealms.DB.Models.Powers.CharacterPowerMappingSetup;
 using ExpressedRealms.DB.Models.Skills;
 using ExpressedRealms.DB.Models.Statistics.CharacterStatMappings;
@@ -44,7 +45,10 @@ public class Character : ISoftDelete
     public int? SecondaryProgressionId { get; set; }
     public virtual ProgressionPath? PrimaryProgressionPath { get; set; }
     public virtual ProgressionPath? SecondaryProgressionPath { get; set; }
-
+    
+    public int? StatModifierGroupId { get; set; }
+    public StatModifierGroup? StatModifierGroup { get; set; }
+    
     public bool IsDeleted { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
 

--- a/api/ExpressedRealms.DB/Models/Characters/CharacterConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Characters/CharacterConfiguration.cs
@@ -32,7 +32,7 @@ public class CharacterConfiguration : IEntityTypeConfiguration<Character>
             .HasForeignKey(x => x.StatModifierGroupId)
             .OnDelete(DeleteBehavior.Restrict)
             .IsRequired(false);
-        
+
         builder
             .HasOne(x => x.PrimaryProgressionPath)
             .WithMany(x => x.PrimaryProgressions)

--- a/api/ExpressedRealms.DB/Models/Characters/CharacterConfiguration.cs
+++ b/api/ExpressedRealms.DB/Models/Characters/CharacterConfiguration.cs
@@ -27,6 +27,13 @@ public class CharacterConfiguration : IEntityTypeConfiguration<Character>
         builder.Property(x => x.SecondaryProgressionId);
 
         builder
+            .HasOne(x => x.StatModifierGroup)
+            .WithMany(x => x.Characters)
+            .HasForeignKey(x => x.StatModifierGroupId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(false);
+        
+        builder
             .HasOne(x => x.PrimaryProgressionPath)
             .WithMany(x => x.PrimaryProgressions)
             .HasForeignKey(x => x.PrimaryProgressionId)

--- a/api/ExpressedRealms.DB/Models/ModifierSystem/StatModifierGroups/StatModifierGroup.cs
+++ b/api/ExpressedRealms.DB/Models/ModifierSystem/StatModifierGroups/StatModifierGroup.cs
@@ -1,4 +1,5 @@
 using ExpressedRealms.DB.Models.Blessings.BlessingLevelSetup;
+using ExpressedRealms.DB.Models.Characters;
 using ExpressedRealms.DB.Models.Expressions.ProgressionPathSetup.ProgressionLevels;
 using ExpressedRealms.DB.Models.ModifierSystem.StatGroupMappings;
 using ExpressedRealms.DB.Models.Powers;
@@ -18,4 +19,6 @@ public class StatModifierGroup
     public virtual List<ProgressionLevel> ProgressionLevels { get; set; } = null!;
     public virtual ICollection<StatModifierGroup> Clones { get; set; } =
         new HashSet<StatModifierGroup>();
+    public virtual ICollection<Character> Characters { get; set; } =
+        new HashSet<Character>();
 }

--- a/api/ExpressedRealms.DB/Models/ModifierSystem/StatModifierGroups/StatModifierGroup.cs
+++ b/api/ExpressedRealms.DB/Models/ModifierSystem/StatModifierGroups/StatModifierGroup.cs
@@ -19,6 +19,5 @@ public class StatModifierGroup
     public virtual List<ProgressionLevel> ProgressionLevels { get; set; } = null!;
     public virtual ICollection<StatModifierGroup> Clones { get; set; } =
         new HashSet<StatModifierGroup>();
-    public virtual ICollection<Character> Characters { get; set; } =
-        new HashSet<Character>();
+    public virtual ICollection<Character> Characters { get; set; } = new HashSet<Character>();
 }

--- a/api/ExpressedRealms.Expressions.API/StatModifiers/Helpers.cs
+++ b/api/ExpressedRealms.Expressions.API/StatModifiers/Helpers.cs
@@ -15,6 +15,8 @@ internal static class Helpers
                 return SourceTableEnum.Blessings;
             case "progressionlevels":
                 return SourceTableEnum.ProgressionLevels;
+            case "characters":
+                return SourceTableEnum.Characters;
             default:
                 throw new InvalidEnumArgumentException(
                     $"{name} was not converted into a valid SourceTableEnum."

--- a/api/ExpressedRealms.Expressions.Repository/StatModifier/IStatModifierRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/StatModifier/IStatModifierRepository.cs
@@ -31,4 +31,5 @@ public interface IStatModifierRepository
         int? primaryProgressionId
     );
     Task UpdateCharacterGroupId(int characterId, int groupId);
+    Task<List<ProficiencyModifierInfoDto>> GetModifiersFromCharacter(int characterId);
 }

--- a/api/ExpressedRealms.Expressions.Repository/StatModifier/IStatModifierRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/StatModifier/IStatModifierRepository.cs
@@ -30,4 +30,5 @@ public interface IStatModifierRepository
         int expressionId,
         int? primaryProgressionId
     );
+    Task UpdateCharacterGroupId(int characterId, int groupId);
 }

--- a/api/ExpressedRealms.Expressions.Repository/StatModifier/StatModifierRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/StatModifier/StatModifierRepository.cs
@@ -170,6 +170,13 @@ public class StatModifierRepository(
         power.StatModifierGroupId = groupId;
         await context.SaveChangesAsync(cancellationToken);
     }
+    
+    public async Task UpdateCharacterGroupId(int characterId, int groupId)
+    {
+        var power = await context.Characters.FirstAsync(x => x.Id == characterId);
+        power.StatModifierGroupId = groupId;
+        await context.SaveChangesAsync(cancellationToken);
+    }
 
     public Task UpdateGroupMapping(StatGroupMapping mapping)
     {

--- a/api/ExpressedRealms.Expressions.Repository/StatModifier/StatModifierRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/StatModifier/StatModifierRepository.cs
@@ -78,6 +78,28 @@ public class StatModifierRepository(
             )
             .ToListAsync();
     }
+    
+    public async Task<List<ProficiencyModifierInfoDto>> GetModifiersFromCharacter(int characterId)
+    {
+        return await context
+            .Characters.Where(x =>
+                x.Id == characterId && x.StatModifierGroup != null
+            )
+            .SelectMany(x =>
+                x.StatModifierGroup!.StatGroupMappings.Select(
+                    y => new ProficiencyModifierInfoDto
+                    {
+                        Source = $"GO Character Override",
+                        Modifier = y.Modifier,
+                        ModifierTypeId = y.StatModifierId,
+                        ScaleWithLevel = y.ScaleWithLevel,
+                        CreationSpecificBonus = y.CreationSpecificBonus,
+                        TargetExpressionId = y.TargetExpressionId,
+                    }
+                )
+            )
+            .ToListAsync();
+    }
 
     public async Task<List<ProficiencyModifierInfoDto>> GetModifiersFromXlLevel(
         int currentLevel,

--- a/api/ExpressedRealms.Expressions.Repository/StatModifier/StatModifierRepository.cs
+++ b/api/ExpressedRealms.Expressions.Repository/StatModifier/StatModifierRepository.cs
@@ -78,25 +78,21 @@ public class StatModifierRepository(
             )
             .ToListAsync();
     }
-    
+
     public async Task<List<ProficiencyModifierInfoDto>> GetModifiersFromCharacter(int characterId)
     {
         return await context
-            .Characters.Where(x =>
-                x.Id == characterId && x.StatModifierGroup != null
-            )
+            .Characters.Where(x => x.Id == characterId && x.StatModifierGroup != null)
             .SelectMany(x =>
-                x.StatModifierGroup!.StatGroupMappings.Select(
-                    y => new ProficiencyModifierInfoDto
-                    {
-                        Source = $"GO Character Override",
-                        Modifier = y.Modifier,
-                        ModifierTypeId = y.StatModifierId,
-                        ScaleWithLevel = y.ScaleWithLevel,
-                        CreationSpecificBonus = y.CreationSpecificBonus,
-                        TargetExpressionId = y.TargetExpressionId,
-                    }
-                )
+                x.StatModifierGroup!.StatGroupMappings.Select(y => new ProficiencyModifierInfoDto
+                {
+                    Source = $"GO Character Override",
+                    Modifier = y.Modifier,
+                    ModifierTypeId = y.StatModifierId,
+                    ScaleWithLevel = y.ScaleWithLevel,
+                    CreationSpecificBonus = y.CreationSpecificBonus,
+                    TargetExpressionId = y.TargetExpressionId,
+                })
             )
             .ToListAsync();
     }
@@ -192,7 +188,7 @@ public class StatModifierRepository(
         power.StatModifierGroupId = groupId;
         await context.SaveChangesAsync(cancellationToken);
     }
-    
+
     public async Task UpdateCharacterGroupId(int characterId, int groupId)
     {
         var power = await context.Characters.FirstAsync(x => x.Id == characterId);

--- a/api/ExpressedRealms.Expressions.UseCases/StatModifiers/Add/AddStatModifierModelValidator.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/StatModifiers/Add/AddStatModifierModelValidator.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using ExpressedRealms.Characters.Repository;
 using ExpressedRealms.Expressions.Repository.Expressions;
 using ExpressedRealms.Expressions.Repository.StatModifier;
 using FluentValidation;
@@ -11,6 +12,7 @@ internal sealed class AddStatModifierModelValidator : AbstractValidator<AddStatM
 {
     public AddStatModifierModelValidator(
         IStatModifierRepository statModifierRepository,
+        ICharacterRepository characterRepository,
         IExpressionRepository expressionRepository
     )
     {
@@ -28,6 +30,8 @@ internal sealed class AddStatModifierModelValidator : AbstractValidator<AddStatM
                             return await statModifierRepository.BlessingLevelExists(x.SourceId);
                         case SourceTableEnum.Powers:
                             return await statModifierRepository.PowerExists(x.SourceId);
+                        case SourceTableEnum.Characters:
+                            return await characterRepository.CharacterExistsAsync(x.SourceId);
                         default:
                             throw new InvalidEnumArgumentException(
                                 nameof(x.SourceTable),

--- a/api/ExpressedRealms.Expressions.UseCases/StatModifiers/Add/AddStatModifierUseCase.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/StatModifiers/Add/AddStatModifierUseCase.cs
@@ -44,6 +44,9 @@ internal sealed class AddStatModifierUseCase(
                 case SourceTableEnum.Powers:
                     await repository.UpdatePowerGroupId(model.SourceId, groupId);
                     break;
+                case SourceTableEnum.Characters:
+                    await repository.UpdateCharacterGroupId(model.SourceId, groupId);
+                    break;
                 default:
                     throw new InvalidEnumArgumentException(
                         nameof(model.SourceTable),

--- a/api/ExpressedRealms.Expressions.UseCases/StatModifiers/Add/SourceTableEnum.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/StatModifiers/Add/SourceTableEnum.cs
@@ -5,5 +5,5 @@ public enum SourceTableEnum
     ProgressionLevels = 1,
     Blessings,
     Powers,
-    Characters
+    Characters,
 }

--- a/api/ExpressedRealms.Expressions.UseCases/StatModifiers/Add/SourceTableEnum.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/StatModifiers/Add/SourceTableEnum.cs
@@ -5,4 +5,5 @@ public enum SourceTableEnum
     ProgressionLevels = 1,
     Blessings,
     Powers,
+    Characters
 }

--- a/api/ExpressedRealms.Expressions.UseCases/StatModifiers/StatModifierPermissionChecks.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/StatModifiers/StatModifierPermissionChecks.cs
@@ -14,6 +14,7 @@ internal class StatModifierPermissionChecks(IUserContext userContext)
         out Result fail
     )
     {
+        const string statModifierString = "Stat Modifier";
         switch (sourceTableEnum)
         {
             case SourceTableEnum.ProgressionLevels:
@@ -21,7 +22,7 @@ internal class StatModifierPermissionChecks(IUserContext userContext)
                     !userContext.CurrentUserHasPermission(Permissions.ProgressionPath.EditModifiers)
                 )
                 {
-                    fail = Result.Fail(new NotFoundFailure("Stat Modifier", ""));
+                    fail = Result.Fail(new NotFoundFailure(statModifierString, ""));
                     return true;
                 }
 
@@ -29,7 +30,7 @@ internal class StatModifierPermissionChecks(IUserContext userContext)
             case SourceTableEnum.Blessings:
                 if (!userContext.CurrentUserHasPermission(Permissions.Blessings.EditModifiers))
                 {
-                    fail = Result.Fail(new NotFoundFailure("Stat Modifier", ""));
+                    fail = Result.Fail(new NotFoundFailure(statModifierString, ""));
                     return true;
                 }
 
@@ -37,7 +38,7 @@ internal class StatModifierPermissionChecks(IUserContext userContext)
             case SourceTableEnum.Powers:
                 if (!userContext.CurrentUserHasPermission(Permissions.Powers.EditModifiers))
                 {
-                    fail = Result.Fail(new NotFoundFailure("Stat Modifier", ""));
+                    fail = Result.Fail(new NotFoundFailure(statModifierString, ""));
                     return true;
                 }
 
@@ -50,7 +51,7 @@ internal class StatModifierPermissionChecks(IUserContext userContext)
                     )
                 )
                 {
-                    fail = Result.Fail(new NotFoundFailure("Stat Modifier", ""));
+                    fail = Result.Fail(new NotFoundFailure(statModifierString, ""));
                     return true;
                 }
 

--- a/api/ExpressedRealms.Expressions.UseCases/StatModifiers/StatModifierPermissionChecks.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/StatModifiers/StatModifierPermissionChecks.cs
@@ -42,9 +42,13 @@ internal class StatModifierPermissionChecks(IUserContext userContext)
                 }
 
                 break;
-            
+
             case SourceTableEnum.Characters:
-                if (!userContext.CurrentUserHasPermission(Permissions.CharacterManagement.EditModifiers))
+                if (
+                    !userContext.CurrentUserHasPermission(
+                        Permissions.CharacterManagement.EditModifiers
+                    )
+                )
                 {
                     fail = Result.Fail(new NotFoundFailure("Stat Modifier", ""));
                     return true;

--- a/api/ExpressedRealms.Expressions.UseCases/StatModifiers/StatModifierPermissionChecks.cs
+++ b/api/ExpressedRealms.Expressions.UseCases/StatModifiers/StatModifierPermissionChecks.cs
@@ -42,6 +42,15 @@ internal class StatModifierPermissionChecks(IUserContext userContext)
                 }
 
                 break;
+            
+            case SourceTableEnum.Characters:
+                if (!userContext.CurrentUserHasPermission(Permissions.CharacterManagement.EditModifiers))
+                {
+                    fail = Result.Fail(new NotFoundFailure("Stat Modifier", ""));
+                    return true;
+                }
+
+                break;
             default:
                 throw new InvalidEnumArgumentException(
                     nameof(sourceTableEnum),

--- a/client/src/components/admin/characterList/UpdateGoFields.vue
+++ b/client/src/components/admin/characterList/UpdateGoFields.vue
@@ -10,6 +10,9 @@ import { useQuery } from '@pinia/colada'
 import { goFieldQuery, useUpdateGoFields } from '@/components/admin/characterList/stores/goFieldColada.ts'
 import type { GoFields } from '@/components/admin/characterList/types.ts'
 import { useHydrateFormOnce } from '@/utilities/piniaColadaUtilities.ts'
+import { SourceTableEnum } from '@/components/modifiergroups/types.ts'
+import ModifierGroup from '@/components/modifiergroups/ModifierGroup.vue'
+import { can } from '@/stores/userPermissionStore.ts'
 
 const form = getValidationInstance()
 const dialogRef = inject('dialogRef') as Ref
@@ -45,4 +48,10 @@ const cancel = () => {
     <FormInputNumberWrapper v-model="form.fields.voidFragments" />
     <Button label="Update" class="m-2" type="submit" />
   </FormWrapper>
+
+  <div v-if="can.CharacterManagement.EditModifiers">
+    <p>For the modifiers below, these are permanent additions to the character sheet recieved via role play.</p>
+    <p>This is not meant to be used to get around bugs in the app</p>
+    <ModifierGroup v-if="!isPending" :group-id="data!.statModifierGroupId" :source="SourceTableEnum.Characters" :source-id="characterId" />
+  </div>
 </template>

--- a/client/src/components/admin/characterList/types.ts
+++ b/client/src/components/admin/characterList/types.ts
@@ -17,4 +17,5 @@ export interface GoFields {
   voidFragments: number
   motes: number
   primaFragments: number
+  statModifierGroupId: number | undefined
 }

--- a/client/src/components/modifiergroups/stores/modifierGroupStore.ts
+++ b/client/src/components/modifiergroups/stores/modifierGroupStore.ts
@@ -32,6 +32,8 @@ const modifierGroupStore
             return can.Powers.EditModifiers
           case SourceTableEnum.ProgressionLevels:
             return can.ProgressionPath.EditModifiers
+          case SourceTableEnum.Characters:
+            return can.CharacterManagement.EditModifiers
           default: return false
         }
       },

--- a/client/src/components/modifiergroups/types.ts
+++ b/client/src/components/modifiergroups/types.ts
@@ -2,6 +2,7 @@ export enum SourceTableEnum {
   ProgressionLevels = 1,
   Blessings = 2,
   Powers = 3,
+  Characters = 4,
 }
 
 export interface CreateStatModifier {

--- a/client/src/types/UserPermissions.ts
+++ b/client/src/types/UserPermissions.ts
@@ -21,6 +21,7 @@ export const UserPermissions = {
     ViewCharacterSheet: 'charactermanagement.viewcharactersheet',
     DownloadAllCrbs: 'charactermanagement.downloadallcrbs',
     ModifyGoFields: 'charactermanagement.modifygofields',
+    EditModifiers: 'charactermanagement.editmodifiers',
   } as const,
   CharacterContacts: {
     Approve: 'charactercontacts.approve',


### PR DESCRIPTION
These will allow Admins to permanently alter character sheets

 - Modifiers can be found in the GO Fields popup
 - Added new Edit Modifiers permission on Character Management - you will need this to see the modifiers
 - Permission will be added to Admin role, regular GO's will not be able to do this
 - Updated Sheet / CRB to pull in the new modifier type